### PR TITLE
Added slog to OmniPaxos.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+slog = "2.7.0"
+slog-term = "2.8.0"
+slog-async = "2.7.0"
+
 [dev-dependencies]
 kompact = { git = "https://github.com/kompics/kompact", rev = "94956af" }
 serial_test = "0.5.1"

--- a/src/leader_election.rs
+++ b/src/leader_election.rs
@@ -247,12 +247,13 @@ pub mod ballot_leader_election {
 
         /// Initiates a new heartbeat round.
         pub fn new_hb_round(&mut self) {
+            self.hb_round += 1;
+
             trace!(
                 self.logger,
                 "Initiate new heartbeat round: {}",
-                self.hb_round + 1
+                self.hb_round
             );
-            debug!(self.logger, "Current heartbeat round: {}", self.hb_round);
 
             self.hb_current_delay = if let Some(initial_delay) = self.initial_delay_factor {
                 debug!(self.logger, "Using initial heartbeat delay");
@@ -264,7 +265,6 @@ pub mod ballot_leader_election {
                 self.hb_delay
             };
 
-            self.hb_round += 1;
             for peer in &self.peers {
                 let hb_request = HeartbeatRequest::with(self.hb_round);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,3 +21,5 @@ pub mod paxos;
 pub mod storage;
 /// A module containing helper functions and structs.
 mod util;
+/// Holds helpful functions for the user.
+pub mod utils;

--- a/src/paxos.rs
+++ b/src/paxos.rs
@@ -37,7 +37,7 @@ pub enum ProposeErr {
 
 /// An Omni-Paxos replica. Maintains local state of the replicated log, handles incoming messages and produces outgoing messages that the user has to fetch periodically and send using a network implementation.
 /// User also has to periodically fetch the decided entries that are guaranteed to be strongly consistent and linearizable, and therefore also safe to be used in the higher level application.
-pub struct Paxos<R, S, P>
+pub struct OmniPaxos<R, S, P>
 where
     R: Round,
     S: Sequence<R>,
@@ -69,7 +69,7 @@ where
     logger: Logger,
 }
 
-impl<R, S, P> Paxos<R, S, P>
+impl<R, S, P> OmniPaxos<R, S, P>
 where
     R: Round,
     S: Sequence<R>,
@@ -93,7 +93,7 @@ where
         skip_prepare_use_leader: Option<Leader<R>>, // skipped prepare phase with the following leader event
         logger: Option<Logger>,
         log_file_path: Option<&str>,
-    ) -> Paxos<R, S, P> {
+    ) -> OmniPaxos<R, S, P> {
         let num_nodes = &peers.len() + 1;
         let majority = num_nodes / 2 + 1;
         let max_peer_pid = peers.iter().max().unwrap();
@@ -129,7 +129,7 @@ where
 
         info!(l, "Paxos component pid: {} created!", pid);
 
-        let mut paxos = Paxos {
+        let mut paxos = OmniPaxos {
             storage,
             pid,
             config_id,
@@ -172,8 +172,8 @@ where
         storage: Storage<R, S, P>,
         skip_prepare_use_leader: Option<Leader<R>>,
         logger: Option<Logger>,
-    ) -> Paxos<R, S, P> {
-        Paxos::<R, S, P>::with(
+    ) -> OmniPaxos<R, S, P> {
+        OmniPaxos::<R, S, P>::with(
             cfg[CONFIG_ID].as_i64().expect("Failed to load config ID") as u32,
             cfg[PID].as_i64().expect("Failed to load PID") as u64,
             peers,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,5 @@
 use crate::leader_election::Round;
-use slog::{o, Drain, Logger};
 use std::cmp::Ordering;
-use std::fs::OpenOptions;
-use std::sync::Mutex;
 
 #[derive(Debug, Clone)]
 /// Promise without the suffix
@@ -65,26 +62,3 @@ where
 }
 
 impl<R> Eq for PromiseMetaData<R> where R: Round {}
-
-pub fn create_logger(file_path: &str) -> Logger {
-    let path = std::path::Path::new(file_path);
-    let prefix = path.parent().unwrap(); // todo change unwrap
-    std::fs::create_dir_all(prefix).unwrap(); // todo change unwrap
-
-    let file = OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(file_path)
-        .unwrap(); // todo change unwrap
-
-    let term_decorator = slog_term::TermDecorator::new().build();
-    let file_decorator = slog_term::PlainSyncDecorator::new(file);
-
-    let term_fuse = slog_term::FullFormat::new(term_decorator).build().fuse();
-    let file_fuse = slog_term::FullFormat::new(file_decorator).build().fuse();
-
-    let both = Mutex::new(slog::Duplicate::new(term_fuse, file_fuse)).fuse();
-    let both = slog_async::Async::new(both).build().fuse();
-    slog::Logger::root(both, o!())
-}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,8 @@
 use crate::leader_election::Round;
+use slog::{o, Drain, Logger};
 use std::cmp::Ordering;
+use std::fs::OpenOptions;
+use std::sync::Mutex;
 
 #[derive(Debug, Clone)]
 /// Promise without the suffix
@@ -62,3 +65,26 @@ where
 }
 
 impl<R> Eq for PromiseMetaData<R> where R: Round {}
+
+pub fn create_logger(file_path: &str) -> Logger {
+    let path = std::path::Path::new(file_path);
+    let prefix = path.parent().unwrap(); // todo change unwrap
+    std::fs::create_dir_all(prefix).unwrap(); // todo change unwrap
+
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(file_path)
+        .unwrap(); // todo change unwrap
+
+    let term_decorator = slog_term::TermDecorator::new().build();
+    let file_decorator = slog_term::PlainSyncDecorator::new(file);
+
+    let term_fuse = slog_term::FullFormat::new(term_decorator).build().fuse();
+    let file_fuse = slog_term::FullFormat::new(file_decorator).build().fuse();
+
+    let both = Mutex::new(slog::Duplicate::new(term_fuse, file_fuse)).fuse();
+    let both = slog_async::Async::new(both).build().fuse();
+    slog::Logger::root(both, o!())
+}

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -1,0 +1,27 @@
+use slog::{o, Drain, Logger};
+use std::fs::OpenOptions;
+use std::sync::Mutex;
+
+/// Creates an asynchronous logger which outputs to both the terminal and a specified file_path.
+pub fn create_logger(file_path: &str) -> Logger {
+    let path = std::path::Path::new(file_path);
+    let prefix = path.parent().unwrap(); // todo change unwrap
+    std::fs::create_dir_all(prefix).unwrap(); // todo change unwrap
+
+    let file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(file_path)
+        .unwrap(); // todo change unwrap
+
+    let term_decorator = slog_term::TermDecorator::new().build();
+    let file_decorator = slog_term::PlainSyncDecorator::new(file);
+
+    let term_fuse = slog_term::FullFormat::new(term_decorator).build().fuse();
+    let file_fuse = slog_term::FullFormat::new(file_decorator).build().fuse();
+
+    let both = Mutex::new(slog::Duplicate::new(term_fuse, file_fuse)).fuse();
+    let both = slog_async::Async::new(both).build().fuse();
+    slog::Logger::root(both, o!())
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,0 +1,2 @@
+/// Holds helpful functions used in creating loggers.
+pub mod logger;

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -82,6 +82,7 @@ impl TestSystem {
                         increment_delay,
                         ble_initial_leader,
                         ble_initial_delay_factor,
+                        None,
                     ),
                 )
             });
@@ -97,6 +98,7 @@ impl TestSystem {
                             MemorySequence::<Ballot>::new(),
                             MemoryState::<Ballot>::new(),
                         ),
+                        None,
                         None,
                     ),
                 )

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -6,7 +6,7 @@ use kompact::config_keys::system;
 use kompact::executors::crossbeam_workstealing_pool;
 use kompact::prelude::*;
 use omnipaxos::leader_election::ballot_leader_election::BallotLeaderElection;
-use omnipaxos::paxos::Paxos;
+use omnipaxos::paxos::OmniPaxos;
 use omnipaxos::storage::memory_storage::{MemorySequence, MemoryState};
 use omnipaxos::storage::{PaxosState, Sequence, Storage};
 use omnipaxos::{
@@ -91,7 +91,7 @@ impl TestSystem {
             let (omni_replica, omni_reg_f) = system.create_and_register(|| {
                 OmniPaxosReplica::with(
                     pid,
-                    Paxos::with(
+                    OmniPaxos::with(
                         1,
                         pid,
                         peer_pids.clone(),
@@ -305,7 +305,7 @@ pub mod ble {
 
 pub mod omnireplica {
     use super::{ble::BallotLeaderElectionPort, *};
-    use omnipaxos::paxos::Paxos;
+    use omnipaxos::paxos::OmniPaxos;
     use omnipaxos::storage::memory_storage::{MemorySequence, MemoryState};
     use omnipaxos::storage::Entry;
     use omnipaxos::{
@@ -322,7 +322,7 @@ pub mod omnireplica {
         pid: u64,
         peers: HashMap<u64, ActorRef<Message<Ballot>>>,
         timer: Option<ScheduledTimer>,
-        paxos: Paxos<Ballot, MemorySequence<Ballot>, MemoryState<Ballot>>,
+        paxos: OmniPaxos<Ballot, MemorySequence<Ballot>, MemoryState<Ballot>>,
         ask_vector: LinkedList<Ask<(), Entry<Ballot>>>,
     }
 
@@ -354,7 +354,7 @@ pub mod omnireplica {
     impl OmniPaxosReplica {
         pub fn with(
             pid: u64,
-            paxos: Paxos<Ballot, MemorySequence<Ballot>, MemoryState<Ballot>>,
+            paxos: OmniPaxos<Ballot, MemorySequence<Ballot>, MemoryState<Ballot>>,
         ) -> Self {
             Self {
                 ctx: ComponentContext::uninitialised(),


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Fixes #3 
Fixes #18
Added slog crate as default logger for the omnipaxos system.
There's no rotation or compression of the log file. The log file grows until all space is consumed.

## Other Changes

Added the option for the user to add their own implementation of logger based on slog.
The default logger outputs to terminal and file.