### PR TITLE
Typed Log Entries, Custom BLE Priority and Reconfiguration Metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ Cargo.lock
 *.iml
 .idea/*
 *.log
+docs/.DS_Store
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ slog-async = "2.7.0"
 hocon = "0.5.2"
 
 [dev-dependencies]
-kompact = { git = "https://github.com/kompics/kompact", rev = "94956af" }
+kompact = { git = "https://github.com/kompics/kompact", rev = "94956af", features = ["silent_logging"]}
 serial_test = "0.5.1"
 rand = "0.8.4"
 

--- a/docs/src/ble/index.md
+++ b/docs/src/ble/index.md
@@ -4,15 +4,18 @@ A unique feature of the Omni-Paxos protocol is guaranteed progress with one quor
 The BLE protocol is based on exchanging heartbeats that should be received within some expected time. To represent time, `BallotLeaderElection` uses an internal logical clock. It has a `tick()` function that progresses its logical clock. The expected time that heartbeats should be received in is specified by `hb_delay` of the `BallotLeaderElection` constructor:
 ```rust,edition2018,no_run,noplaypen
 BallotLeaderElection::with(
-    peers: Vec<u64>,    // the PEERS of this server. I.e. this should not include `pid`    
-    pid: u64,           // the unique identifier of this server
-    hb_delay: u64,      // the delay that is waited for heartbeat responses from peers. Measured in number of `tick()` calls.
-    initial_leader: Option<Leader<Ballot>>,     // initial leader
-    initial_delay_factor: Option<u64>,          // allows for using a shorter delay when electing the initial leader.
+    peers: Vec<u64>,        // the PEERS of this server. I.e. this should not include `pid`    
+    pid: u64,               // the unique identifier of this server
+    hb_delay: u64,          // the delay that is waited for heartbeat responses from peers. Measured in number of `tick()` calls.
+    priority: Option<u64>,  // custom priority parameter.
+    initial_leader: Option<Ballot>,     // initial leader
+    initial_delay_factor: Option<u64>,  // allows for using a shorter delay when electing the initial leader.
     logger: Option<Logger>,
     log_file_path: Option<&str>,
 )
 ```
+> **Note** The `priority` parameter allows user to give desired servers a higher priority to become the leader. This is a best-effort approach upon a leader election or failure.
+
 For instance, we can create a BLE instance with a timeout of 800ms that is ticked every 100ms. The user has to call `tick()` every 100ms themselves and check if a leader has been elected. Once a leader is elected, `tick()` will return an instance of the struct `Leader<Ballot>`. This should be passed to the corresponding local `OmniPaxos` instance using `OmniPaxos::handle_leader()`, which will in turn use the `Ballot` as a round number for log replication.
 
 ```rust,edition2018,no_run,noplaypen
@@ -31,7 +34,8 @@ let omni_paxos = OmniPaxos::with(... , my_pid, my_peers, ...); // see `OmniPaxos
 let ble = BallotLeaderElection::with(
     my_peers,
     my_pid,
-    hb_delay
+    None,
+    hb_delay,
     None,
     initial_delay_factor,
     None,

--- a/docs/src/introduction/index.md
+++ b/docs/src/introduction/index.md
@@ -1,4 +1,4 @@
 # Introduction
 
-The OmniPaxos library is mainly driven by the [**OmniPaxos**](../omnipaxos/index.md) and [**Ballot Leader Election**](../ble/index.md) (*BLE*) structs.  These are plain Rust structs and the user therefore needs to provide a network implementation themselves to actually send and receive messages. In this tutorial we will show how a user should interact with these structs in order to implement a fault-tolerant replicated log. This tutorial will focus on how to use the library and showcase its features. 
+The OmniPaxos library is mainly driven by the [**OmniPaxos**](../omnipaxos/index.md) and [**Ballot Leader Election**](../ble/index.md) (*BLE*) structs.  These are plain Rust structs and the user therefore needs to provide a network implementation themselves to actually send and receive messages. In this tutorial we will show how a user should interact with these structs in order to implement a strongly consistent, replicated log. This tutorial will focus on how to use the library and showcase its features. 
 <!-- For the properties and advantages of OmniPaxos in comparison to other similar protocols, we refer to the Omni-Paxos paper. -->

--- a/docs/src/omnipaxos/communication.md
+++ b/docs/src/omnipaxos/communication.md
@@ -5,30 +5,41 @@ As previously mentioned, the user has to send/receive messages between servers t
 To propose a log entry to be replicated, the `OmniPaxos::propose_normal()` function is called (we reuse the `storage` and `omni_paxos` variables created in earlier [examples](../omnipaxos/index.md)):
 
 ```rust,edition2018,no_run,noplaypen
-let data: Vec<u8> = ... ;   // log entry as raw bytes
-omni_paxos.propose_normal(data).expect("Failed to propose normal proposal");
+let kv = KeyValue { key: String::from("a"), value: "123" } ;   // log entry as raw bytes
+omni_paxos.propose_normal(kv).expect("Failed to propose normal proposal");
 ```
 
 Proposals can be pipelined without waiting for preceeding entries to be decided. Furthermore, `propose_normal` can be called on any server. If the calling server is not the leader, the proposal will be forwarded. 
-
-> **Note** For now, we only support proposing and deciding raw byte log entries with `Vec<u8>`. However, it would be possible to use a generic log entry type `T`. We would be more than happy to guide/help anyone interested in implementing this :)
 
 ## Incoming and Outgoing
 By proposing a log entry, the `OmniPaxos` instance will produce outgoing messages to its peers. The outgoing messages can be accessed by calling `OmniPaxos::get_outgoing_msgs()`. These messages then need to be sent to the intended server by the user themselves on the network layer. An incoming message should then be handled with the function `OmniPaxos::handle()`. Handling the incoming message will change the state and produce outgoing messages of `OmniPaxos` according to the protocol.
 ```rust,edition2018,no_run,noplaypen
 // send outgoing messages (this should be called periodically, e.g. every 500ms)
-for out_msg in omni_paxos.get_outgoings_msgs() {
+for out_msg: Message<KeyValue> in omni_paxos.get_outgoings_msgs() {
     let receiver = out_msg.to;
     // send out_msg to receiver on network layer
 }
 
 // handle incoming message on network layer
-let msg: PaxosMsg = ...;    // message received to this server.
+let msg: PaxosMsg:<KeyValue> = ...;    // message received to this server.
 omni_paxos.handle(msg);
 ```
 
 ## Decided Entries
-If a server is not partitioned from the leader, its local instance eventually decide log entries that are guaranteed to be consistent and linearizable. Thus, these entries can be fetched via `OmniPaxos::get_latest_decided_entries()` and are safe to be handled by a higher level application. 
+Once an entry has been appended to the log on a majority of the cluster, it has been **decided**. The decided entries can be fetched via `OmniPaxos::get_latest_decided_entries()` and are safe to be handled by a higher level application that requires strong consistency.
+
+
+```rust,edition2018,no_run,noplaypen
+// handle decided log entries periodically
+for entry in omni_paxos.get_latest_decided_entries() {
+    match entry {
+        Entry::Normal(e) => {    // handle decided normal log entry
+            // e is of type KeyValue that was proposed.
+        }
+        _ => { /* see next section about reconfiguration */ }
+    }
+}
+```
 
 > **Note** `get_latest_decided_entries()` returns all the decided elements **since the last time it was called** and is thus intended to be called periodically. To get all decided entries (since the start), use `get_decided_entries()`
 
@@ -43,15 +54,13 @@ omni_paxos.propose_reconfiguration(new_cluster, None).expect("Failed to propose 
 // handle decided log entries periodically
 for entry in omni_paxos.get_latest_decided_entries() {
     match entry {
-        Entry::Normal(data) => {    // handle decided normal log entry
-            // data in Vec<u8> that was proposed.
-        }
+        Entry::Normal(_) => { /* See previous section */ }
+    
         Entry::StopSign(ss) => {    // handle completed reconfiguration
             let next_configuration_id = ss.config_id;
             let next_cluster = ss.nodes;
             let next_leader = ss.skip_prepare_use_leader;   // if Some(), then the replica instances in the new
                                                             // configuration should use this in their constructor
-            // handle reconfiguration
         }
     }
 }
@@ -60,7 +69,8 @@ for entry in omni_paxos.get_latest_decided_entries() {
 Upon deciding a `StopSign`, the user should create a new replica instance with the new configuration id if the corresponding server is in `StopSign.nodes`. Furthermore, the user should also notify and migrate the log to any new servers joining the cluster. To stop the old instance and get the final log in the old configuration, one can call:
 
 ```rust,edition2018,no_run,noplaypen
-let final_seq = self.omni_paxos.stop_and_get_sequence();
+let log: Vec<Entry<KeyValue>> = self.omni_paxos.stop_and_get_sequence();
 // notify about reconfiguration and migrate log to new servers
 ```
-The user has to implement the log migration themselves. We do not support it since depending on the deployed environment, it could require specific migration schemes to achieve best performance and lowest cost.
+
+> **Note** The user has to implement the log migration themselves before starting the new `OmniPaxos` instances.

--- a/docs/src/omnipaxos/index.md
+++ b/docs/src/omnipaxos/index.md
@@ -2,19 +2,21 @@
 
 Each server in the cluster should have a local instance of the  `OmniPaxos` struct. `OmniPaxos` maintains a local state of the replicated log, handles incoming messages and produces outgoing messages that the user has to fetch and send using their network implementation. The user also has to fetch the decided entries that are guaranteed to be strongly consistent and linearizable, and therefore also safe to be used in a higher-level application.
 
-> **Note:** `OmniPaxos` has a type parameter `R` that must implement the trait `Round`. This is the round numbers used in the log replication. It will be provided and furthered explained in [Ballot Leader Election](../ble/index.md), but for simplicity the reader can for now assume `R` to be `u64`.
+## Example: Key-Value store
+As a guide for this tutorial, we will use OmniPaxos to implement a replicated log for the purpose of a consistent Key-Value store. 
+
+We begin by defining the type that we want our log entries to consist of:
+```rust,edition2018,no_run,noplaypen
+pub struct KeyValue {
+    pub key: String,
+    pub value: u64
+}
+``` 
 
 ## Storage
-The replicated log can be stored using any underlying implementation provided by the user. OmniPaxos only requires a user to implement the traits `PaxosState<R>` and `Sequence<R>`. The `PaxosState<R>` maintains the internal state of the `OmniPaxos`, while `Sequence<R>` maintains the actual replicated log. The storage is split into these two traits since `PaxosState<R>` stores small values such as indexes, while `Sequence<R>` stores larger data (the log entries). Thus it is possible to tailor-fit the implementations respectively. 
+The replicated log can be stored using any underlying implementation provided by the user. OmniPaxos only requires the user to implement the traits `PaxosState` and `Sequence<T>`. The `PaxosState` maintains the internal state of the protocol, while `Sequence<T>` maintains the actual replicated log. In our example, `T` is `KeyValue`. The storage is split into these two traits since `PaxosState` stores small values such as indexes, while `Sequence<T>` stores larger data (the log entries). Thus it is possible to tailor-fit the implementations respectively. 
 
-### Example: In-memory storage
-OmniPaxos provides an in-memory storage implementation in the traits `MemorySequence` and `MemoryState`.
-
-```rust,edition2018,no_run,noplaypen
-use omnipaxos::storage::memory_storage::{MemorySequence, MemoryState, Storage};
-
-let storage = Storage::with(MemorySequence::<R>::new(), MemoryState::<R>::new());
-``` 
+OmniPaxos provides an in-memory storage implementation in the structs `MemoryState` and `MemorySequence<T>`.
 
 ## Creating an OmniPaxos instance
 The constructor of `OmniPaxos` has the following parameters.
@@ -24,14 +26,13 @@ OmniPaxos::with(
     config_id: u32,                                 // the configuration id. See the section "Reconfiguration" in `Communication`.
     pid: u64,                                       // the unique identifier of this server
     peers: Vec<u64>,                                // the PEERS of this server. I.e. this should not include `pid`
-    storage: Storage<R, S, P>,
-    skip_prepare_use_leader: Option<Leader<R>>,     // optimization to start with pre-determined leader after
+    skip_prepare_use_leader: Option<Ballot>,        // optimization to start with pre-determined leader after
                                                     // reconfiguration. See "Reconfiguration".
     logger: Option<Logger>,                         // custom logger
     log_file_path: Option<&str>,                    
 )
 ```
-With the initialized storage, we can go ahead and create our `OmniPaxos` replica instance:
+Let's go ahead and create our `OmniPaxos` replica instance:
 ```rust,edition2018,no_run,noplaypen
 use omnipaxos::paxos::OmniPaxos;
 
@@ -43,7 +44,7 @@ let _cluster = vec![1, 2, 3];
 let my_pid = 2;
 let my_peers= vec![1, 3];
 
-let omni_paxos = OmniPaxos::with(
+let omni_paxos: OmniPaxos<KeyValue, MemorySequence, MemoryState> = OmniPaxos::with(
     configuration_id,
     my_pid,
     my_peers,

--- a/src/leader_election.rs
+++ b/src/leader_election.rs
@@ -79,8 +79,8 @@ pub mod ballot_leader_election {
         /// * `log_file_path` - Path where the default logger logs events.
         #[allow(clippy::too_many_arguments)]
         pub fn with(
-            peers: Vec<u64>,
             pid: u64,
+            peers: Vec<u64>,
             priority: Option<u64>,
             hb_delay: u64,
             initial_leader: Option<Ballot>,
@@ -130,15 +130,14 @@ pub mod ballot_leader_election {
         /// * `initial_leader` -  Initial leader which will be elected.
         /// * `logger` - Used for logging events of Ballot Leader Election.
         pub fn with_hocon(
-            &self,
             cfg: &Hocon,
             peers: Vec<u64>,
             initial_leader: Option<Ballot>,
             logger: Option<Logger>,
         ) -> BallotLeaderElection {
             BallotLeaderElection::with(
-                peers,
                 cfg[PID].as_i64().expect("Failed to load PID") as u64,
+                peers,
                 cfg[PRIORITY].as_i64().map(|p| p as u64),
                 cfg[HB_DELAY]
                     .as_i64()
@@ -175,7 +174,6 @@ pub mod ballot_leader_election {
         /// Returns an Option with the elected leader otherwise None
         pub fn tick(&mut self) -> Option<Ballot> {
             self.ticks_elapsed += 1;
-
             if self.ticks_elapsed >= self.hb_current_delay {
                 self.ticks_elapsed = 0;
                 self.hb_timeout()
@@ -241,7 +239,6 @@ pub mod ballot_leader_election {
         /// Initiates a new heartbeat round.
         pub fn new_hb_round(&mut self) {
             self.hb_round += 1;
-
             trace!(
                 self.logger,
                 "Initiate new heartbeat round: {}",
@@ -269,7 +266,6 @@ pub mod ballot_leader_election {
 
         fn hb_timeout(&mut self) -> Option<Ballot> {
             trace!(self.logger, "Heartbeat timeout round: {}", self.hb_round);
-
             let result: Option<Ballot> = if self.ballots.len() + 1 >= self.majority {
                 debug!(
                     self.logger,
@@ -294,7 +290,6 @@ pub mod ballot_leader_election {
 
         fn handle_request(&mut self, from: u64, req: HeartbeatRequest) {
             trace!(self.logger, "Heartbeat request from {}", from);
-
             let hb_reply =
                 HeartbeatReply::with(req.round, self.current_ballot, self.majority_connected);
 
@@ -307,7 +302,6 @@ pub mod ballot_leader_election {
 
         fn handle_reply(&mut self, rep: HeartbeatReply) {
             trace!(self.logger, "Heartbeat reply {:?}", rep.ballot);
-
             if rep.round == self.hb_round {
                 self.ballots.push((rep.ballot, rep.majority_connected));
             } else {

--- a/src/leader_election.rs
+++ b/src/leader_election.rs
@@ -1,49 +1,21 @@
-use std::fmt::Debug;
-
-/// Rounds in Omni-Paxos must be totally ordered.
-pub trait Round: Clone + Debug + Ord + Default + Send + 'static {}
-
-/// Leader event that indicates a leader has been elected. Should be created when the user-defined BLE algorithm
-/// outputs a leader event. Should be then handled in Omni-Paxos by calling [`crate::paxos::Paxos::handle_leader()`].
-#[derive(Copy, Clone, Debug)]
-pub struct Leader<R>
-where
-    R: Round,
-{
-    /// The pid of the elected leader.
-    pub pid: u64,
-    /// The round in which `pid` is elected in.
-    pub round: R,
-}
-
-impl<R> Leader<R>
-where
-    R: Round,
-{
-    /// Constructor for [`Leader`].
-    pub fn with(pid: u64, round: R) -> Self {
-        Leader { pid, round }
-    }
-}
-
 /// Ballot Leader Election algorithm for electing new leaders
 pub mod ballot_leader_election {
-    use crate::{
-        leader_election::{Leader, Round},
-        utils::{
-            hocon_kv::{HB_DELAY, INITIAL_DELAY_FACTOR, LOG_FILE_PATH, PID},
-            logger::create_logger,
-        },
+    use crate::utils::{
+        hocon_kv::{HB_DELAY, INITIAL_DELAY_FACTOR, LOG_FILE_PATH, PID},
+        logger::create_logger,
     };
     use hocon::Hocon;
     use messages::{BLEMessage, HeartbeatMsg, HeartbeatReply, HeartbeatRequest};
     use slog::{debug, info, trace, warn, Logger};
+    use crate::utils::hocon_kv::PRIORITY;
 
     /// Used to define an epoch
     #[derive(Clone, Copy, Eq, Debug, Default, Ord, PartialOrd, PartialEq)]
     pub struct Ballot {
         /// Ballot number
         pub n: u32,
+        /// Custom priority parameter
+        pub priority: u64,
         /// The pid of the process
         pub pid: u64,
     }
@@ -52,13 +24,12 @@ pub mod ballot_leader_election {
         /// Creates a new Ballot
         /// # Arguments
         /// * `n` - Ballot number.
+        /// * `priority` - Custom priority parameter.
         /// * `pid` -  Used as tiebreaker for total ordering of ballots.
-        pub fn with(n: u32, pid: u64) -> Ballot {
-            Ballot { n, pid }
+        pub fn with(n: u32, priority: u64, pid: u64) -> Ballot {
+            Ballot { n, priority, pid }
         }
     }
-
-    impl Round for Ballot {}
 
     /// A Ballot Leader Election component. Used in conjunction with Omni-Paxos handles the election of a leader for a group of omni-paxos replicas,
     /// incoming messages and produces outgoing messages that the user has to fetch periodically and send using a network implementation.
@@ -101,35 +72,27 @@ pub mod ballot_leader_election {
         /// # Arguments
         /// * `peers` - Vector that holds all the other replicas.
         /// * `pid` -  Process identifier used to uniquely identify this instance.
+        /// * `priority` - Custom priority parameter.
         /// * `hb_delay` -  A fixed delay that is added to the current_delay. It is measured in ticks.
         /// * `initial_leader` -  Initial leader which will be elected.
         /// * `initial_delay_factor` -  A factor used in the beginning for a shorter hb_delay.
         /// * `logger` - Used for logging events of Ballot Leader Election.
         /// * `log_file_path` - Path where the default logger logs events.
+        #[allow(clippy::too_many_arguments)]
         pub fn with(
             peers: Vec<u64>,
             pid: u64,
+            priority: Option<u64>,
             hb_delay: u64,
-            initial_leader: Option<Leader<Ballot>>,
+            initial_leader: Option<Ballot>,
             initial_delay_factor: Option<u64>,
             logger: Option<Logger>,
             log_file_path: Option<&str>,
         ) -> BallotLeaderElection {
             let n = &peers.len() + 1;
-            let (leader, initial_ballot) = match initial_leader {
-                Some(l) => {
-                    let leader_ballot = Ballot::with(l.round.n, l.pid);
-                    let initial_ballot = if l.pid == pid {
-                        leader_ballot
-                    } else {
-                        Ballot::with(0, pid)
-                    };
-                    (Some(leader_ballot), initial_ballot)
-                }
-                None => {
-                    let initial_ballot = Ballot::with(0, pid);
-                    (None, initial_ballot)
-                }
+            let initial_ballot = match initial_leader {
+                Some(leader_ballot) if leader_ballot.pid == pid => leader_ballot,
+                _ => Ballot::with(0, priority.unwrap_or_default(), pid),
             };
 
             let l = logger.unwrap_or_else(|| {
@@ -151,7 +114,7 @@ pub mod ballot_leader_election {
                 ballots: Vec::with_capacity(n),
                 current_ballot: initial_ballot,
                 majority_connected: true,
-                leader,
+                leader: initial_leader,
                 hb_current_delay: hb_delay,
                 hb_delay,
                 initial_delay_factor,
@@ -171,12 +134,13 @@ pub mod ballot_leader_election {
             &self,
             cfg: &Hocon,
             peers: Vec<u64>,
-            initial_leader: Option<Leader<Ballot>>,
+            initial_leader: Option<Ballot>,
             logger: Option<Logger>,
         ) -> BallotLeaderElection {
             BallotLeaderElection::with(
                 peers,
                 cfg[PID].as_i64().expect("Failed to load PID") as u64,
+                cfg[PRIORITY].as_i64().map(|p| p as u64),
                 cfg[HB_DELAY]
                     .as_i64()
                     .expect("Failed to load heartbeat delay") as u64,
@@ -192,21 +156,25 @@ pub mod ballot_leader_election {
             )
         }
 
-        /// Returns the outgoing vector
+        /// Update the custom priority used in the Ballot for this server.
+        pub fn set_priority(&mut self, p: u64) {
+            self.current_ballot.priority = p;
+        }
+
+        /// Returns outgoing messages
         pub fn get_outgoing_msgs(&mut self) -> Vec<BLEMessage> {
             std::mem::take(&mut self.outgoing)
         }
 
         /// Returns the currently elected leader.
-        pub fn get_leader(&self) -> Option<Leader<Ballot>> {
+        pub fn get_leader(&self) -> Option<Ballot> {
             self.leader
-                .map(|ballot: Ballot| -> Leader<Ballot> { Leader::with(ballot.pid, ballot) })
         }
 
         /// Tick is run by all servers to simulate the passage of time
         /// If one wishes to have hb_delay of 500ms, one can set a periodic timer of 100ms to call tick(). After 5 calls to this function, the timeout will occur.
         /// Returns an Option with the elected leader otherwise None
-        pub fn tick(&mut self) -> Option<Leader<Ballot>> {
+        pub fn tick(&mut self) -> Option<Ballot> {
             self.ticks_elapsed += 1;
 
             if self.ticks_elapsed >= self.hb_current_delay {
@@ -227,23 +195,19 @@ pub mod ballot_leader_election {
             }
         }
 
-        /// Sets initial state after creation. Should only be used before being started.
+        /// Sets initial state after creation. *Must only be used before being started*.
         /// # Arguments
-        /// * `l` - Initial leader.
-        pub fn set_initial_leader(&mut self, l: Leader<Ballot>) {
+        /// * `leader_ballot` - Initial leader.
+        pub fn set_initial_leader(&mut self, leader_ballot: Ballot) {
             assert!(self.leader.is_none());
-            let leader_ballot = Ballot::with(l.round.n, l.pid);
-            self.leader = Some(leader_ballot);
-            if l.pid == self.pid {
+            if leader_ballot.pid == self.pid {
                 self.current_ballot = leader_ballot;
                 self.majority_connected = true;
-            } else {
-                self.current_ballot = Ballot::with(0, self.pid);
-                self.majority_connected = false;
-            };
+            }
+            self.leader = Some(leader_ballot);
         }
 
-        fn check_leader(&mut self) -> Option<Leader<Ballot>> {
+        fn check_leader(&mut self) -> Option<Ballot> {
             let ballots = std::mem::take(&mut self.ballots);
             let top_ballot = ballots
                 .into_iter()
@@ -264,17 +228,12 @@ pub mod ballot_leader_election {
                 self.current_ballot.n = self.leader.unwrap_or_default().n + 1;
                 self.leader = None;
                 self.majority_connected = true;
-
                 None
             } else if self.leader != Some(top_ballot) {
                 // got a new leader with greater ballot
                 self.leader = Some(top_ballot);
-                let top_pid = top_ballot.pid;
-                debug!(
-                    self.logger,
-                    "New Leader elected, pid: {}, ballot: {:?}", top_pid, top_ballot
-                );
-                Some(Leader::with(top_pid, top_ballot))
+                debug!(self.logger, "New Leader elected: {:?}", top_ballot);
+                Some(top_ballot)
             } else {
                 None
             }
@@ -309,10 +268,10 @@ pub mod ballot_leader_election {
             }
         }
 
-        fn hb_timeout(&mut self) -> Option<Leader<Ballot>> {
+        fn hb_timeout(&mut self) -> Option<Ballot> {
             trace!(self.logger, "Heartbeat timeout round: {}", self.hb_round);
 
-            let result: Option<Leader<Ballot>> = if self.ballots.len() + 1 >= self.majority {
+            let result: Option<Ballot> = if self.ballots.len() + 1 >= self.majority {
                 debug!(
                     self.logger,
                     "Received a majority of heartbeats {:?}", self.ballots

--- a/src/leader_election.rs
+++ b/src/leader_election.rs
@@ -1,13 +1,12 @@
 /// Ballot Leader Election algorithm for electing new leaders
 pub mod ballot_leader_election {
     use crate::utils::{
-        hocon_kv::{HB_DELAY, INITIAL_DELAY_FACTOR, LOG_FILE_PATH, PID},
+        hocon_kv::{HB_DELAY, INITIAL_DELAY_FACTOR, LOG_FILE_PATH, PID, PRIORITY},
         logger::create_logger,
     };
     use hocon::Hocon;
     use messages::{BLEMessage, HeartbeatMsg, HeartbeatReply, HeartbeatRequest};
     use slog::{debug, info, trace, warn, Logger};
-    use crate::utils::hocon_kv::PRIORITY;
 
     /// Used to define an epoch
     #[derive(Clone, Copy, Eq, Debug, Default, Ord, PartialOrd, PartialEq)]

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -29,7 +29,7 @@ impl Prepare {
 #[derive(Clone, Debug)]
 pub struct Promise<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// The current round.
     pub n: Ballot,
@@ -45,7 +45,7 @@ where
 
 impl<T> Promise<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Creates a [`Promise`] message.
     pub fn with(n: Ballot, n_accepted: Ballot, sfx: Vec<Entry<T>>, ld: u64, la: u64) -> Self {
@@ -63,7 +63,7 @@ where
 #[derive(Clone, Debug)]
 pub struct AcceptSync<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// The current round.
     pub n: Ballot,
@@ -75,7 +75,7 @@ where
 
 impl<T> AcceptSync<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Creates an [`AcceptSync`] message.
     pub fn with(n: Ballot, sfx: Vec<Entry<T>>, sync_idx: u64) -> Self {
@@ -91,7 +91,7 @@ where
 #[derive(Clone, Debug)]
 pub struct FirstAccept<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// The current round.
     pub n: Ballot,
@@ -101,7 +101,7 @@ where
 
 impl<T> FirstAccept<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Creates a [`FirstAccept`] message.
     pub fn with(n: Ballot, entries: Vec<Entry<T>>) -> Self {
@@ -113,7 +113,7 @@ where
 #[derive(Clone, Debug)]
 pub struct AcceptDecide<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// The current round.
     pub n: Ballot,
@@ -125,7 +125,7 @@ where
 
 impl<T> AcceptDecide<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Creates an [`AcceptDecide`] message.
     pub fn with(n: Ballot, ld: u64, entries: Vec<Entry<T>>) -> Self {
@@ -170,7 +170,7 @@ impl Decide {
 #[derive(Clone, Debug)]
 pub enum PaxosMsg<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Ballotequest a [`Prepare`] to be sent from the leader. Used for fail-recovery.
     PrepareReq,
@@ -192,7 +192,7 @@ where
 #[derive(Clone, Debug)]
 pub struct Message<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Sender of `msg`.
     pub from: u64,
@@ -204,7 +204,7 @@ where
 
 impl<T> Message<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Creates a message.
     pub fn with(from: u64, to: u64, msg: PaxosMsg<T>) -> Self {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,27 +1,21 @@
-use crate::{leader_election::Round, storage::Entry};
+use crate::{leader_election::ballot_leader_election::Ballot, storage::Entry};
 
 /// Prepare message sent by a newly-elected leader to initiate the Prepare phase.
-#[derive(Clone, Debug)]
-pub struct Prepare<R>
-where
-    R: Round,
-{
+#[derive(Copy, Clone, Debug)]
+pub struct Prepare {
     /// The current round.
-    pub n: R,
+    pub n: Ballot,
     /// The decided index of this leader.
     pub ld: u64,
     /// The latest round in which an entry was accepted.
-    pub n_accepted: R,
+    pub n_accepted: Ballot,
     /// The log length of this leader.
     pub la: u64,
 }
 
-impl<R> Prepare<R>
-where
-    R: Round,
-{
+impl Prepare {
     /// Creates a [`Prepare`] message.
-    pub fn with(n: R, ld: u64, n_accepted: R, la: u64) -> Self {
+    pub fn with(n: Ballot, ld: u64, n_accepted: Ballot, la: u64) -> Self {
         Prepare {
             n,
             ld,
@@ -33,15 +27,14 @@ where
 
 /// Promise message sent by a follower in response to a [`Prepare`] sent by the leader.
 #[derive(Clone, Debug)]
-pub struct Promise<R, T>
+pub struct Promise<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// The current round.
-    pub n: R,
+    pub n: Ballot,
     /// The latest round in which an entry was accepted.
-    pub n_accepted: R,
+    pub n_accepted: Ballot,
     /// The suffix of missing entries at the leader.
     pub sfx: Vec<Entry<T>>,
     /// The decided index of this follower.
@@ -50,13 +43,12 @@ where
     pub la: u64,
 }
 
-impl<R, T> Promise<R, T>
+impl<T> Promise<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// Creates a [`Promise`] message.
-    pub fn with(n: R, n_accepted: R, sfx: Vec<Entry<T>>, ld: u64, la: u64) -> Self {
+    pub fn with(n: Ballot, n_accepted: Ballot, sfx: Vec<Entry<T>>, ld: u64, la: u64) -> Self {
         Promise {
             n,
             n_accepted,
@@ -69,26 +61,24 @@ where
 
 /// AcceptSync message sent by the leader to synchronize the logs of all replicas in the prepare phase.
 #[derive(Clone, Debug)]
-pub struct AcceptSync<R, T>
+pub struct AcceptSync<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// The current round.
-    pub n: R,
+    pub n: Ballot,
     /// Entries that the receiving replica is missing in its log.
     pub entries: Vec<Entry<T>>,
     /// The index of the log where `entries` should be applied at.
     pub sync_idx: u64,
 }
 
-impl<R, T> AcceptSync<R, T>
+impl<T> AcceptSync<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// Creates an [`AcceptSync`] message.
-    pub fn with(n: R, sfx: Vec<Entry<T>>, sync_idx: u64) -> Self {
+    pub fn with(n: Ballot, sfx: Vec<Entry<T>>, sync_idx: u64) -> Self {
         AcceptSync {
             n,
             entries: sfx,
@@ -99,94 +89,78 @@ where
 
 /// The first accept message sent. Only used by a pre-elected leader after reconfiguration.
 #[derive(Clone, Debug)]
-pub struct FirstAccept<R, T>
+pub struct FirstAccept<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// The current round.
-    pub n: R,
+    pub n: Ballot,
     /// Entries to be replicated.
     pub entries: Vec<Entry<T>>,
 }
 
-impl<R, T> FirstAccept<R, T>
+impl<T> FirstAccept<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// Creates a [`FirstAccept`] message.
-    pub fn with(n: R, entries: Vec<Entry<T>>) -> Self {
+    pub fn with(n: Ballot, entries: Vec<Entry<T>>) -> Self {
         FirstAccept { n, entries }
     }
 }
 
 /// Message with entries to be replicated and the latest decided index sent by the leader in the accept phase.
 #[derive(Clone, Debug)]
-pub struct AcceptDecide<R, T>
+pub struct AcceptDecide<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// The current round.
-    pub n: R,
+    pub n: Ballot,
     /// The decided index.
     pub ld: u64,
     /// Entries to be replicated.
     pub entries: Vec<Entry<T>>,
 }
 
-impl<R, T> AcceptDecide<R, T>
+impl<T> AcceptDecide<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// Creates an [`AcceptDecide`] message.
-    pub fn with(n: R, ld: u64, entries: Vec<Entry<T>>) -> Self {
+    pub fn with(n: Ballot, ld: u64, entries: Vec<Entry<T>>) -> Self {
         AcceptDecide { n, ld, entries }
     }
 }
 
 /// Message sent by follower to leader when entries has been accepted.
-#[derive(Clone, Debug)]
-pub struct Accepted<R>
-where
-    R: Round,
-{
+#[derive(Copy, Clone, Debug)]
+pub struct Accepted {
     /// The current round.
-    pub n: R,
+    pub n: Ballot,
     /// The accepted index.
     pub la: u64,
 }
 
-impl<R> Accepted<R>
-where
-    R: Round,
-{
+impl Accepted {
     /// Creates an [`Accepted`] message.
-    pub fn with(n: R, la: u64) -> Self {
+    pub fn with(n: Ballot, la: u64) -> Self {
         Accepted { n, la }
     }
 }
 
 /// Message sent by leader to followers to decide up to a certain index in the log.
-#[derive(Clone, Debug)]
-pub struct Decide<R>
-where
-    R: Round,
-{
+#[derive(Copy, Clone,  Debug)]
+pub struct Decide {
     /// The current round.
-    pub n: R,
+    pub n: Ballot,
     /// The decided index.
     pub ld: u64,
 }
 
-impl<R> Decide<R>
-where
-    R: Round,
-{
+impl Decide {
     /// Creates a [`Decide`] message.
-    pub fn with(n: R, ld: u64) -> Self {
+    pub fn with(n: Ballot, ld: u64) -> Self {
         Decide { n, ld }
     }
 }
@@ -194,21 +168,20 @@ where
 /// An enum for all the different message types.
 #[allow(missing_docs)]
 #[derive(Clone, Debug)]
-pub enum PaxosMsg<R, T>
+pub enum PaxosMsg<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
-    /// Request a [`Prepare`] to be sent from the leader. Used for fail-recovery.
+    /// Ballotequest a [`Prepare`] to be sent from the leader. Used for fail-recovery.
     PrepareReq,
     #[allow(missing_docs)]
-    Prepare(Prepare<R>),
-    Promise(Promise<R, T>),
-    AcceptSync(AcceptSync<R, T>),
-    FirstAccept(FirstAccept<R, T>),
-    AcceptDecide(AcceptDecide<R, T>),
-    Accepted(Accepted<R>),
-    Decide(Decide<R>),
+    Prepare(Prepare),
+    Promise(Promise<T>),
+    AcceptSync(AcceptSync<T>),
+    FirstAccept(FirstAccept<T>),
+    AcceptDecide(AcceptDecide<T>),
+    Accepted(Accepted),
+    Decide(Decide),
     /// Forward client proposals to the leader.
     ProposalForward(Vec<Entry<T>>),
     GarbageCollect(u64),
@@ -217,26 +190,24 @@ where
 
 /// A struct for a Paxos message that also includes sender and receiver.
 #[derive(Clone, Debug)]
-pub struct Message<R, T>
+pub struct Message<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// Sender of `msg`.
     pub from: u64,
-    /// Receiver of `msg`.
+    /// Balloteceiver of `msg`.
     pub to: u64,
     /// The message content.
-    pub msg: PaxosMsg<R, T>,
+    pub msg: PaxosMsg<T>,
 }
 
-impl<R, T> Message<R, T>
+impl<T> Message<T>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
 {
     /// Creates a message.
-    pub fn with(from: u64, to: u64, msg: PaxosMsg<R, T>) -> Self {
+    pub fn with(from: u64, to: u64, msg: PaxosMsg<T>) -> Self {
         Message { from, to, msg }
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -33,28 +33,30 @@ where
 
 /// Promise message sent by a follower in response to a [`Prepare`] sent by the leader.
 #[derive(Clone, Debug)]
-pub struct Promise<R>
+pub struct Promise<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// The current round.
     pub n: R,
     /// The latest round in which an entry was accepted.
     pub n_accepted: R,
     /// The suffix of missing entries at the leader.
-    pub sfx: Vec<Entry<R>>,
+    pub sfx: Vec<Entry<T>>,
     /// The decided index of this follower.
     pub ld: u64,
     /// The log length of this follower.
     pub la: u64,
 }
 
-impl<R> Promise<R>
+impl<R, T> Promise<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Creates a [`Promise`] message.
-    pub fn with(n: R, n_accepted: R, sfx: Vec<Entry<R>>, ld: u64, la: u64) -> Self {
+    pub fn with(n: R, n_accepted: R, sfx: Vec<Entry<T>>, ld: u64, la: u64) -> Self {
         Promise {
             n,
             n_accepted,
@@ -67,24 +69,26 @@ where
 
 /// AcceptSync message sent by the leader to synchronize the logs of all replicas in the prepare phase.
 #[derive(Clone, Debug)]
-pub struct AcceptSync<R>
+pub struct AcceptSync<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// The current round.
     pub n: R,
     /// Entries that the receiving replica is missing in its log.
-    pub entries: Vec<Entry<R>>,
+    pub entries: Vec<Entry<T>>,
     /// The index of the log where `entries` should be applied at.
     pub sync_idx: u64,
 }
 
-impl<R> AcceptSync<R>
+impl<R, T> AcceptSync<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Creates an [`AcceptSync`] message.
-    pub fn with(n: R, sfx: Vec<Entry<R>>, sync_idx: u64) -> Self {
+    pub fn with(n: R, sfx: Vec<Entry<T>>, sync_idx: u64) -> Self {
         AcceptSync {
             n,
             entries: sfx,
@@ -95,46 +99,50 @@ where
 
 /// The first accept message sent. Only used by a pre-elected leader after reconfiguration.
 #[derive(Clone, Debug)]
-pub struct FirstAccept<R>
+pub struct FirstAccept<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// The current round.
     pub n: R,
     /// Entries to be replicated.
-    pub entries: Vec<Entry<R>>,
+    pub entries: Vec<Entry<T>>,
 }
 
-impl<R> FirstAccept<R>
+impl<R, T> FirstAccept<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Creates a [`FirstAccept`] message.
-    pub fn with(n: R, entries: Vec<Entry<R>>) -> Self {
+    pub fn with(n: R, entries: Vec<Entry<T>>) -> Self {
         FirstAccept { n, entries }
     }
 }
 
 /// Message with entries to be replicated and the latest decided index sent by the leader in the accept phase.
 #[derive(Clone, Debug)]
-pub struct AcceptDecide<R>
+pub struct AcceptDecide<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// The current round.
     pub n: R,
     /// The decided index.
     pub ld: u64,
     /// Entries to be replicated.
-    pub entries: Vec<Entry<R>>,
+    pub entries: Vec<Entry<T>>,
 }
 
-impl<R> AcceptDecide<R>
+impl<R, T> AcceptDecide<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Creates an [`AcceptDecide`] message.
-    pub fn with(n: R, ld: u64, entries: Vec<Entry<R>>) -> Self {
+    pub fn with(n: R, ld: u64, entries: Vec<Entry<T>>) -> Self {
         AcceptDecide { n, ld, entries }
     }
 }
@@ -186,46 +194,49 @@ where
 /// An enum for all the different message types.
 #[allow(missing_docs)]
 #[derive(Clone, Debug)]
-pub enum PaxosMsg<R>
+pub enum PaxosMsg<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Request a [`Prepare`] to be sent from the leader. Used for fail-recovery.
     PrepareReq,
     #[allow(missing_docs)]
     Prepare(Prepare<R>),
-    Promise(Promise<R>),
-    AcceptSync(AcceptSync<R>),
-    FirstAccept(FirstAccept<R>),
-    AcceptDecide(AcceptDecide<R>),
+    Promise(Promise<R, T>),
+    AcceptSync(AcceptSync<R, T>),
+    FirstAccept(FirstAccept<R, T>),
+    AcceptDecide(AcceptDecide<R, T>),
     Accepted(Accepted<R>),
     Decide(Decide<R>),
     /// Forward client proposals to the leader.
-    ProposalForward(Vec<Entry<R>>),
+    ProposalForward(Vec<Entry<T>>),
     GarbageCollect(u64),
     ForwardGarbageCollect(Option<u64>),
 }
 
 /// A struct for a Paxos message that also includes sender and receiver.
 #[derive(Clone, Debug)]
-pub struct Message<R>
+pub struct Message<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Sender of `msg`.
     pub from: u64,
     /// Receiver of `msg`.
     pub to: u64,
     /// The message content.
-    pub msg: PaxosMsg<R>,
+    pub msg: PaxosMsg<R, T>,
 }
 
-impl<R> Message<R>
+impl<R, T> Message<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Creates a message.
-    pub fn with(from: u64, to: u64, msg: PaxosMsg<R>) -> Self {
+    pub fn with(from: u64, to: u64, msg: PaxosMsg<R, T>) -> Self {
         Message { from, to, msg }
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -150,7 +150,7 @@ impl Accepted {
 }
 
 /// Message sent by leader to followers to decide up to a certain index in the log.
-#[derive(Copy, Clone,  Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Decide {
     /// The current round.
     pub n: Ballot,

--- a/src/paxos.rs
+++ b/src/paxos.rs
@@ -34,7 +34,7 @@ enum Role {
 #[derive(Debug)]
 pub enum ProposeErr<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     Normal(T),
     Reconfiguration(Vec<u64>), // TODO use a type for ProcessId
@@ -44,7 +44,7 @@ where
 /// User also has to periodically fetch the decided entries that are guaranteed to be strongly consistent and linearizable, and therefore also safe to be used in the higher level application.
 pub struct OmniPaxos<T, S, P>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
     S: Sequence<T>,
     P: PaxosState,
 {
@@ -76,7 +76,7 @@ where
 
 impl<T, S, P> OmniPaxos<T, S, P>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
     S: Sequence<T>,
     P: PaxosState,
 {

--- a/src/paxos.rs
+++ b/src/paxos.rs
@@ -1,5 +1,5 @@
 use crate::{
-    leader_election::*,
+    leader_election::ballot_leader_election::Ballot,
     messages::*,
     storage::{Entry, PaxosState, Sequence, StopSign, Storage},
     util::PromiseMetaData,
@@ -42,45 +42,43 @@ where
 
 /// An Omni-Paxos replica. Maintains local state of the replicated log, handles incoming messages and produces outgoing messages that the user has to fetch periodically and send using a network implementation.
 /// User also has to periodically fetch the decided entries that are guaranteed to be strongly consistent and linearizable, and therefore also safe to be used in the higher level application.
-pub struct OmniPaxos<R, T, S, P>
+pub struct OmniPaxos<T, S, P>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
     S: Sequence<T>,
-    P: PaxosState<R>,
+    P: PaxosState,
 {
-    storage: Storage<R, T, S, P>,
+    storage: Storage<T, S, P>,
     config_id: u32,
     pid: u64,
     majority: usize,
     peers: Vec<u64>, // excluding self pid
     state: (Role, Phase),
     leader: u64,
-    n_leader: R,
-    promises_meta: Vec<Option<PromiseMetaData<R>>>,
+    n_leader: Ballot,
+    promises_meta: Vec<Option<PromiseMetaData>>,
     las: Vec<u64>,
     lds: Vec<Option<u64>>,
     proposals: Vec<Entry<T>>,
     lc: u64, // length of longest chosen seq
     prev_ld: u64,
-    max_promise_meta: PromiseMetaData<R>,
+    max_promise_meta: PromiseMetaData,
     max_promise_sfx: Option<Vec<Entry<T>>>,
-    batch_accept_meta: Vec<Option<(R, usize)>>, //  R, index in outgoing
-    latest_decide_meta: Vec<Option<(R, usize)>>,
-    latest_accepted_meta: Option<(R, usize)>,
-    outgoing: Vec<Message<R, T>>,
+    batch_accept_meta: Vec<Option<(Ballot, usize)>>, //  index in outgoing
+    latest_decide_meta: Vec<Option<(Ballot, usize)>>,
+    latest_accepted_meta: Option<(Ballot, usize)>,
+    outgoing: Vec<Message<T>>,
     num_nodes: usize,
     /// Logger used to output the status of the component.
     logger: Logger,
     cached_gc_index: u64,
 }
 
-impl<R, T, S, P> OmniPaxos<R, T, S, P>
+impl<T, S, P> OmniPaxos<T, S, P>
 where
-    R: Round,
     T: AsRef<u8> + Clone,
     S: Sequence<T>,
-    P: PaxosState<R>,
+    P: PaxosState,
 {
     /*** User functions ***/
     /// Creates an Omni-Paxos replica.
@@ -95,10 +93,10 @@ where
         config_id: u32,
         pid: u64,
         peers: Vec<u64>,
-        skip_prepare_use_leader: Option<Leader<R>>, // skipped prepare phase with the following leader event
+        skip_prepare_use_leader: Option<Ballot>, // skipped prepare phase with the following leader event
         logger: Option<Logger>,
         log_file_path: Option<&str>,
-    ) -> OmniPaxos<R, T, S, P> {
+    ) -> OmniPaxos<T, S, P> {
         let num_nodes = &peers.len() + 1;
         let majority = num_nodes / 2 + 1;
         let max_peer_pid = peers.iter().max().unwrap();
@@ -119,12 +117,12 @@ where
                     (Role::Follower, vec![None; num_nodes])
                 };
                 let state = (role, Phase::FirstAccept);
-                (state, l.pid, l.round, lds)
+                (state, l.pid, l, lds)
             }
             None => {
                 let state = (Role::Follower, Phase::None);
                 let lds = vec![None; num_nodes];
-                (state, 0, R::default(), lds)
+                (state, 0, Ballot::default(), lds)
             }
         };
 
@@ -147,14 +145,14 @@ where
             peers,
             state,
             leader,
-            n_leader: n_leader.clone(),
+            n_leader,
             promises_meta: vec![None; num_nodes],
             las: vec![0; num_nodes],
             lds,
             proposals: Vec::with_capacity(BUFFER_SIZE),
             lc: 0,
             prev_ld: 0,
-            max_promise_meta: PromiseMetaData::with(R::default(), 0, 0),
+            max_promise_meta: PromiseMetaData::with(Ballot::default(), 0, 0),
             max_promise_sfx: None,
             batch_accept_meta: vec![None; num_nodes],
             latest_decide_meta: vec![None; num_nodes],
@@ -179,10 +177,10 @@ where
         &self,
         cfg: &Hocon,
         peers: Vec<u64>,
-        skip_prepare_use_leader: Option<Leader<R>>,
+        skip_prepare_use_leader: Option<Ballot>,
         logger: Option<Logger>,
-    ) -> OmniPaxos<R, T, S, P> {
-        OmniPaxos::<R, T, S, P>::with(
+    ) -> OmniPaxos<T, S, P> {
+        OmniPaxos::<T, S, P>::with(
             cfg[CONFIG_ID].as_i64().expect("Failed to load config ID") as u32,
             cfg[PID].as_i64().expect("Failed to load PID") as u64,
             peers,
@@ -292,7 +290,7 @@ where
     }
 
     /// Returns the outgoing messages from this replica. The messages should then be sent via the network implementation.
-    pub fn get_outgoing_msgs(&mut self) -> Vec<Message<R, T>> {
+    pub fn get_outgoing_msgs(&mut self) -> Vec<Message<T>> {
         let mut outgoing = Vec::with_capacity(BUFFER_SIZE);
         std::mem::swap(&mut self.outgoing, &mut outgoing);
         #[cfg(feature = "batch_accept")]
@@ -332,7 +330,7 @@ where
     }
 
     /// Handle an incoming message.
-    pub fn handle(&mut self, m: Message<R, T>) {
+    pub fn handle(&mut self, m: Message<T>) {
         match m.msg {
             PaxosMsg::PrepareReq => self.handle_preparereq(m.from),
             PaxosMsg::Prepare(prep) => self.handle_prepare(prep, m.from),
@@ -408,7 +406,7 @@ where
     }
 
     /// Returns the currently promised round.
-    pub fn get_promise(&self) -> R {
+    pub fn get_promise(&self) -> Ballot {
         self.storage.get_promise()
     }
 
@@ -449,15 +447,11 @@ where
         pid as usize - 1
     }
 
-    /// Handle becoming the leader. Should be called when the leader election has elected this replica as the leader
+    /// Handle a new leader. Should be called when the leader election has elected a new leader with the ballot `n`
     /*** Leader ***/
-    pub fn handle_leader(&mut self, l: Leader<R>) {
-        debug!(
-            self.logger,
-            "Replica got elected as the leader, round: {:?}", l.round
-        );
-        let n = l.round;
-        let leader_pid = l.pid;
+    pub fn handle_leader(&mut self, n: Ballot) {
+        debug!(self.logger, "Newly elected leader: {:?}", n);
+        let leader_pid = n.pid;
         if n <= self.n_leader || n <= self.storage.get_promise() {
             return;
         }
@@ -466,15 +460,15 @@ where
             self.proposals.clear();
         }
         if self.pid == leader_pid {
-            self.n_leader = n.clone();
+            self.n_leader = n;
             self.leader = leader_pid;
-            self.storage.set_promise(n.clone());
+            self.storage.set_promise(n);
             /* insert my promise */
             let na = self.storage.get_accepted_round();
             let ld = self.storage.get_decided_len();
             let la = self.storage.get_sequence_len();
             let promise_meta = PromiseMetaData::with(na, la, self.pid);
-            self.max_promise_meta = promise_meta.clone();
+            self.max_promise_meta = promise_meta;
             self.promises_meta[self.pid as usize - 1] = Some(promise_meta);
             self.max_promise_sfx = None;
             /* initialise longest chosen sequence and update state */
@@ -486,7 +480,7 @@ where
                 self.outgoing.push(Message::with(
                     self.pid,
                     *pid,
-                    PaxosMsg::Prepare(prep.clone()),
+                    PaxosMsg::Prepare(prep),
                 ));
             }
         } else {
@@ -510,7 +504,7 @@ where
             let ld = self.storage.get_decided_len();
             let n_accepted = self.storage.get_accepted_round();
             let la = self.storage.get_sequence_len();
-            let prep = Prepare::with(self.n_leader.clone(), ld, n_accepted, la);
+            let prep = Prepare::with(self.n_leader, ld, n_accepted, la);
             self.outgoing
                 .push(Message::with(self.pid, from, PaxosMsg::Prepare(prep)));
         }
@@ -576,7 +570,7 @@ where
             .enumerate()
             .filter(|(_, x)| x.is_some())
             .map(|(idx, _)| idx as u64 + 1);
-        let f = FirstAccept::with(self.n_leader.clone(), vec![entry.clone()]);
+        let f = FirstAccept::with(self.n_leader, vec![entry.clone()]);
         for pid in promised_pids {
             self.outgoing.push(Message::with(
                 self.pid,
@@ -609,8 +603,7 @@ where
                         }
                     }
                     _ => {
-                        let acc =
-                            AcceptDecide::with(self.n_leader.clone(), self.lc, vec![entry.clone()]);
+                        let acc = AcceptDecide::with(self.n_leader, self.lc, vec![entry.clone()]);
                         let cache_idx = self.outgoing.len();
                         let pid = idx as u64 + 1;
                         self.outgoing.push(Message::with(
@@ -618,16 +611,16 @@ where
                             pid,
                             PaxosMsg::AcceptDecide(acc),
                         ));
-                        self.batch_accept_meta[idx] = Some((self.n_leader.clone(), cache_idx));
+                        self.batch_accept_meta[idx] = Some((self.n_leader, cache_idx));
                         #[cfg(feature = "latest_decide")]
                         {
-                            self.latest_decide_meta[idx] = Some((self.n_leader.clone(), cache_idx));
+                            self.latest_decide_meta[idx] = Some((self.n_leader, cache_idx));
                         }
                     }
                 }
             } else {
                 let pid = idx as u64 + 1;
-                let acc = AcceptDecide::with(self.n_leader.clone(), self.lc, vec![entry.clone()]);
+                let acc = AcceptDecide::with(self.n_leader, self.lc, vec![entry.clone()]);
                 self.outgoing
                     .push(Message::with(self.pid, pid, PaxosMsg::AcceptDecide(acc)));
             }
@@ -658,8 +651,7 @@ where
                         }
                     }
                     _ => {
-                        let acc =
-                            AcceptDecide::with(self.n_leader.clone(), self.lc, entries.clone());
+                        let acc = AcceptDecide::with(self.n_leader, self.lc, entries.clone());
                         let cache_idx = self.outgoing.len();
                         let pid = idx as u64 + 1;
                         self.outgoing.push(Message::with(
@@ -667,16 +659,16 @@ where
                             pid,
                             PaxosMsg::AcceptDecide(acc),
                         ));
-                        self.batch_accept_meta[idx] = Some((self.n_leader.clone(), cache_idx));
+                        self.batch_accept_meta[idx] = Some((self.n_leader, cache_idx));
                         #[cfg(feature = "latest_decide")]
                         {
-                            self.latest_decide_meta[idx] = Some((self.n_leader.clone(), cache_idx));
+                            self.latest_decide_meta[idx] = Some((self.n_leader, cache_idx));
                         }
                     }
                 }
             } else {
                 let pid = idx as u64 + 1;
-                let acc = AcceptDecide::with(self.n_leader.clone(), self.lc, entries.clone());
+                let acc = AcceptDecide::with(self.n_leader, self.lc, entries.clone());
                 self.outgoing
                     .push(Message::with(self.pid, pid, PaxosMsg::AcceptDecide(acc)));
             }
@@ -685,7 +677,7 @@ where
         self.las[self.pid as usize - 1] = la;
     }
 
-    fn handle_promise_prepare(&mut self, prom: Promise<R, T>, from: u64) {
+    fn handle_promise_prepare(&mut self, prom: Promise<T>, from: u64) {
         let (r, p) = &self.state;
         debug!(
             self.logger,
@@ -694,7 +686,7 @@ where
         if prom.n == self.n_leader {
             let promise_meta = PromiseMetaData::with(prom.n_accepted, prom.la, from);
             if promise_meta > self.max_promise_meta {
-                self.max_promise_meta = promise_meta.clone();
+                self.max_promise_meta = promise_meta;
                 self.max_promise_sfx = Some(prom.sfx);
             }
             let idx = Self::get_idx_from_pid(from);
@@ -731,10 +723,10 @@ where
                 // create accept_sync with only new proposals for all pids with max_promise
                 let mut new_entries = std::mem::take(&mut self.proposals);
                 let max_promise_acc_sync =
-                    AcceptSync::with(self.n_leader.clone(), new_entries.clone(), *max_la);
+                    AcceptSync::with(self.n_leader, new_entries.clone(), *max_la);
                 // append new proposals in my sequence
                 let la = self.storage.append_sequence(&mut new_entries);
-                self.storage.set_accepted_round(self.n_leader.clone());
+                self.storage.set_accepted_round(self.n_leader);
                 self.las[Self::get_idx_from_pid(self.pid)] = la;
                 self.state = (Role::Leader, Phase::Accept);
                 let leader_pid = self.pid;
@@ -758,7 +750,7 @@ where
                         )
                     } else if (promise_n == max_promise_n) && (promise_la < max_la) {
                         let sfx = self.storage.get_suffix(*promise_la - self.cached_gc_index);
-                        let acc_sync = AcceptSync::with(self.n_leader.clone(), sfx, *promise_la);
+                        let acc_sync = AcceptSync::with(self.n_leader, sfx, *promise_la);
                         Message::with(self.pid, *pid, PaxosMsg::AcceptSync(acc_sync))
                     } else {
                         let idx = Self::get_idx_from_pid(*pid);
@@ -768,7 +760,7 @@ where
                             .expect("Received PromiseMetaData but not found in ld")
                             .unwrap();
                         let sfx = self.storage.get_suffix(ld - self.cached_gc_index);
-                        let acc_sync = AcceptSync::with(self.n_leader.clone(), sfx, ld);
+                        let acc_sync = AcceptSync::with(self.n_leader, sfx, ld);
                         Message::with(self.pid, *pid, PaxosMsg::AcceptSync(acc_sync))
                     };
                     self.outgoing.push(msg);
@@ -776,14 +768,14 @@ where
                     {
                         let idx = Self::get_idx_from_pid(*pid);
                         self.batch_accept_meta[idx] =
-                            Some((self.n_leader.clone(), self.outgoing.len() - 1));
+                            Some((self.n_leader, self.outgoing.len() - 1));
                     }
                 }
             }
         }
     }
 
-    fn handle_promise_accept(&mut self, prom: Promise<R, T>, from: u64) {
+    fn handle_promise_accept(&mut self, prom: Promise<T>, from: u64) {
         let (r, p) = &self.state;
         debug!(
             self.logger,
@@ -806,13 +798,12 @@ where
                 prom.ld
             };
             let sfx = self.storage.get_suffix(sync_idx - self.cached_gc_index);
-            let acc_sync = AcceptSync::with(self.n_leader.clone(), sfx, sync_idx);
+            let acc_sync = AcceptSync::with(self.n_leader, sfx, sync_idx);
             let msg = Message::with(self.pid, from, PaxosMsg::AcceptSync(acc_sync));
             self.outgoing.push(msg);
             #[cfg(feature = "batch_accept")]
             {
-                self.batch_accept_meta[idx] =
-                    Some((self.n_leader.clone(), self.outgoing.len() - 1));
+                self.batch_accept_meta[idx] = Some((self.n_leader, self.outgoing.len() - 1));
             }
             // inform what got decided already
             let ld = if self.lc > 0 {
@@ -821,19 +812,19 @@ where
                 self.storage.get_decided_len()
             };
             if ld > prom.ld {
-                let d = Decide::with(self.n_leader.clone(), ld);
+                let d = Decide::with(self.n_leader, ld);
                 self.outgoing
                     .push(Message::with(self.pid, from, PaxosMsg::Decide(d)));
                 #[cfg(feature = "latest_decide")]
                 {
                     let cached_idx = self.outgoing.len() - 1;
-                    self.latest_decide_meta[idx] = Some((self.n_leader.clone(), cached_idx));
+                    self.latest_decide_meta[idx] = Some((self.n_leader, cached_idx));
                 }
             }
         }
     }
 
-    fn handle_accepted(&mut self, accepted: Accepted<R>, from: u64) {
+    fn handle_accepted(&mut self, accepted: Accepted, from: u64) {
         trace!(self.logger, "Incoming message Accepted {}", from);
         if accepted.n == self.n_leader && self.state == (Role::Leader, Phase::Accept) {
             self.las[from as usize - 1] = accepted.la;
@@ -842,7 +833,7 @@ where
                     self.las.iter().filter(|la| *la >= &accepted.la).count() >= self.majority;
                 if chosen {
                     self.lc = accepted.la;
-                    let d = Decide::with(self.n_leader.clone(), self.lc);
+                    let d = Decide::with(self.n_leader, self.lc);
                     if cfg!(feature = "latest_decide") {
                         let promised_idx =
                             self.lds.iter().enumerate().filter(|(_, ld)| ld.is_some());
@@ -855,21 +846,19 @@ where
                                         PaxosMsg::AcceptDecide(a) => a.ld = self.lc,
                                         PaxosMsg::Decide(d) => d.ld = self.lc,
                                         _ => {
-                                            panic!(
-                                                "Cached Message<R, T> in outgoing was not Decide"
-                                            )
+                                            panic!("Cached Message<T> in outgoing was not Decide")
                                         }
                                     }
                                 }
                                 _ => {
                                     let cache_dec_idx = self.outgoing.len();
                                     self.latest_decide_meta[idx] =
-                                        Some((self.n_leader.clone(), cache_dec_idx));
+                                        Some((self.n_leader, cache_dec_idx));
                                     let pid = idx as u64 + 1;
                                     self.outgoing.push(Message::with(
                                         self.pid,
                                         pid,
-                                        PaxosMsg::Decide(d.clone()),
+                                        PaxosMsg::Decide(d),
                                     ));
                                 }
                             }
@@ -885,7 +874,7 @@ where
                             self.outgoing.push(Message::with(
                                 self.pid,
                                 pid,
-                                PaxosMsg::Decide(d.clone()),
+                                PaxosMsg::Decide(d),
                             ));
                         }
                     }
@@ -896,10 +885,10 @@ where
     }
 
     /*** Follower ***/
-    fn handle_prepare(&mut self, prep: Prepare<R>, from: u64) {
+    fn handle_prepare(&mut self, prep: Prepare, from: u64) {
         if self.storage.get_promise() <= prep.n {
             self.leader = from;
-            self.storage.set_promise(prep.n.clone());
+            self.storage.set_promise(prep.n);
             self.state = (Role::Follower, Phase::Prepare);
             let na = self.storage.get_accepted_round();
             let la = self.storage.get_sequence_len();
@@ -916,10 +905,10 @@ where
         }
     }
 
-    fn handle_acceptsync(&mut self, accsync: AcceptSync<R, T>, from: u64) {
+    fn handle_acceptsync(&mut self, accsync: AcceptSync<T>, from: u64) {
         if self.storage.get_promise() == accsync.n && self.state == (Role::Follower, Phase::Prepare)
         {
-            self.storage.set_accepted_round(accsync.n.clone());
+            self.storage.set_accepted_round(accsync.n);
             let mut entries = accsync.entries;
             let la = self
                 .storage
@@ -928,7 +917,7 @@ where
             #[cfg(feature = "latest_accepted")]
             {
                 let cached_idx = self.outgoing.len();
-                self.latest_accepted_meta = Some((accsync.n.clone(), cached_idx));
+                self.latest_accepted_meta = Some((accsync.n, cached_idx));
             }
             let accepted = Accepted::with(accsync.n, la);
             self.outgoing
@@ -941,11 +930,11 @@ where
         }
     }
 
-    fn handle_firstaccept(&mut self, f: FirstAccept<R, T>) {
+    fn handle_firstaccept(&mut self, f: FirstAccept<T>) {
         debug!(self.logger, "Incoming message First Accept");
         if self.storage.get_promise() == f.n && self.state == (Role::Follower, Phase::FirstAccept) {
             let mut entries = f.entries;
-            self.storage.set_accepted_round(f.n.clone());
+            self.storage.set_accepted_round(f.n);
             self.accept_entries(f.n, &mut entries);
             self.state.1 = Phase::Accept;
             /*** Forward proposals ***/
@@ -956,7 +945,7 @@ where
         }
     }
 
-    fn handle_acceptdecide(&mut self, acc: AcceptDecide<R, T>) {
+    fn handle_acceptdecide(&mut self, acc: AcceptDecide<T>) {
         if self.storage.get_promise() == acc.n && self.state == (Role::Follower, Phase::Accept) {
             let mut entries = acc.entries;
             self.accept_entries(acc.n, &mut entries);
@@ -967,7 +956,7 @@ where
         }
     }
 
-    fn handle_decide(&mut self, dec: Decide<R>) {
+    fn handle_decide(&mut self, dec: Decide) {
         if self.storage.get_promise() == dec.n && self.state.1 == Phase::Accept {
             self.storage.set_decided_len(dec.ld);
         }
@@ -982,7 +971,7 @@ where
         };
     }
 
-    fn accept_entries(&mut self, n: R, entries: &mut Vec<Entry<T>>) {
+    fn accept_entries(&mut self, n: Ballot, entries: &mut Vec<Entry<T>>) {
         let la = self.storage.append_sequence(entries);
         if cfg!(feature = "latest_accepted") {
             match &self.latest_accepted_meta {
@@ -990,11 +979,11 @@ where
                     let Message { msg, .. } = self.outgoing.get_mut(*outgoing_idx).unwrap();
                     match msg {
                         PaxosMsg::Accepted(a) => a.la = la,
-                        _ => panic!("Cached idx is not an Accepted Message<R, T>!"),
+                        _ => panic!("Cached idx is not an Accepted Message<T>!"),
                     }
                 }
                 _ => {
-                    let accepted = Accepted::with(n.clone(), la);
+                    let accepted = Accepted::with(n, la);
                     let cached_idx = self.outgoing.len();
                     self.latest_accepted_meta = Some((n, cached_idx));
                     self.outgoing.push(Message::with(

--- a/src/paxos.rs
+++ b/src/paxos.rs
@@ -42,14 +42,14 @@ where
 
 /// An Omni-Paxos replica. Maintains local state of the replicated log, handles incoming messages and produces outgoing messages that the user has to fetch periodically and send using a network implementation.
 /// User also has to periodically fetch the decided entries that are guaranteed to be strongly consistent and linearizable, and therefore also safe to be used in the higher level application.
-pub struct OmniPaxos<R, S, T, P>
+pub struct OmniPaxos<R, T, S, P>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
     S: Sequence<T>,
     P: PaxosState<R, T>,
-    T: AsRef<u8> + Clone,
 {
-    storage: Storage<R, S, T, P>,
+    storage: Storage<R, T, S, P>,
     config_id: u32,
     pid: u64,
     majority: usize,
@@ -74,12 +74,12 @@ where
     cached_gc_index: u64,
 }
 
-impl<R, S, T, P> OmniPaxos<R, S, T, P>
+impl<R, T, S, P> OmniPaxos<R, T, S, P>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
     S: Sequence<T>,
     P: PaxosState<R, T>,
-    T: AsRef<u8> + Clone,
 {
     /*** User functions ***/
     /// Creates an Omni-Paxos replica.
@@ -97,7 +97,7 @@ where
         skip_prepare_use_leader: Option<Leader<R>>, // skipped prepare phase with the following leader event
         logger: Option<Logger>,
         log_file_path: Option<&str>,
-    ) -> OmniPaxos<R, S, T, P> {
+    ) -> OmniPaxos<R, T, S, P> {
         let num_nodes = &peers.len() + 1;
         let majority = num_nodes / 2 + 1;
         let max_peer_pid = peers.iter().max().unwrap();
@@ -179,8 +179,8 @@ where
         peers: Vec<u64>,
         skip_prepare_use_leader: Option<Leader<R>>,
         logger: Option<Logger>,
-    ) -> OmniPaxos<R, S, T, P> {
-        OmniPaxos::<R, S, T, P>::with(
+    ) -> OmniPaxos<R, T, S, P> {
+        OmniPaxos::<R, T, S, P>::with(
             cfg[CONFIG_ID].as_i64().expect("Failed to load config ID") as u32,
             cfg[PID].as_i64().expect("Failed to load PID") as u64,
             peers,

--- a/src/paxos.rs
+++ b/src/paxos.rs
@@ -477,11 +477,8 @@ where
             let prep = Prepare::with(n, ld, self.storage.get_accepted_round(), la);
             /* send prepare */
             for pid in &self.peers {
-                self.outgoing.push(Message::with(
-                    self.pid,
-                    *pid,
-                    PaxosMsg::Prepare(prep),
-                ));
+                self.outgoing
+                    .push(Message::with(self.pid, *pid, PaxosMsg::Prepare(prep)));
             }
         } else {
             self.state.0 = Role::Follower;
@@ -871,11 +868,8 @@ where
                             .filter(|(_, ld)| ld.is_some())
                             .map(|(idx, _)| idx as u64 + 1);
                         for pid in promised_pids {
-                            self.outgoing.push(Message::with(
-                                self.pid,
-                                pid,
-                                PaxosMsg::Decide(d),
-                            ));
+                            self.outgoing
+                                .push(Message::with(self.pid, pid, PaxosMsg::Decide(d)));
                         }
                     }
                     self.handle_decide(d);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 #[derive(Clone, Debug, PartialEq)]
 pub enum Entry<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// A normal entry proposed by the client.
     Normal(T),
@@ -15,7 +15,7 @@ where
 
 impl<T> Entry<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Returns true if the entry is a stopsign else, returns false.
     pub fn is_stopsign(&self) -> bool {
@@ -54,7 +54,7 @@ impl PartialEq for StopSign {
 /// Trait to implement a back-end for the log replicated by an Omni-Paxos replica.
 pub trait Sequence<T>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     /// Creates an empty log.
     fn new() -> Self;
@@ -121,7 +121,7 @@ pub trait PaxosState {
 enum PaxosSequence<S, T>
 where
     S: Sequence<T>,
-    T: AsRef<u8> + Clone,
+    T: Clone,
 {
     Active(S),
     Stopped(Arc<S>),
@@ -132,7 +132,7 @@ where
 /// A storage back-end to be used for Omni-Paxos.
 pub(crate) struct Storage<T, S, P>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
     S: Sequence<T>,
     P: PaxosState,
 {
@@ -142,7 +142,7 @@ where
 
 impl<T, S, P> Storage<T, S, P>
 where
-    T: AsRef<u8> + Clone,
+    T: Clone,
     S: Sequence<T>,
     P: PaxosState,
 {
@@ -326,7 +326,7 @@ pub mod memory_storage {
     #[derive(Debug)]
     pub struct MemorySequence<T>
     where
-        T: AsRef<u8> + Clone,
+        T: Clone,
     {
         /// Vector which contains all the logged entries in-memory.
         sequence: Vec<Entry<T>>,
@@ -334,7 +334,7 @@ pub mod memory_storage {
 
     impl<T> Sequence<T> for MemorySequence<T>
     where
-        T: AsRef<u8> + Clone,
+        T: Clone,
     {
         fn new() -> Self {
             MemorySequence { sequence: vec![] }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,21 +1,21 @@
-use crate::leader_election::{Leader, Round};
+use crate::leader_election::Round;
 use std::{fmt::Debug, marker::PhantomData, sync::Arc};
 
 /// An entry in the replicated log.
 #[derive(Clone, Debug, PartialEq)]
-pub enum Entry<R>
+pub enum Entry<T>
 where
-    R: Round,
+    T: AsRef<u8> + Clone,
 {
-    /// A normal entry proposed by the client. Clients propose serialised data as [`Vec<u8>`]
-    Normal(Vec<u8>),
+    /// A normal entry proposed by the client.
+    Normal(T),
     /// A StopSign entry used for reconfiguration. See [`StopSign`].
-    StopSign(StopSign<R>),
+    StopSign(StopSign),
 }
 
-impl<R> Entry<R>
+impl<T> Entry<T>
 where
-    R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Returns true if the entry is a stopsign else, returns false.
     pub fn is_stopsign(&self) -> bool {
@@ -25,70 +25,57 @@ where
 
 /// A StopSign entry that marks the end of a configuration. Used for reconfiguration.
 #[derive(Clone, Debug)]
-pub struct StopSign<R>
-where
-    R: Round,
-{
+pub struct StopSign {
     /// The identifier for the new configuration.
     pub config_id: u32,
     /// The process ids of the new configuration.
     pub nodes: Vec<u64>,
-    /// Option to use a pre-elected leader for the new configuration and skip prepare phase when starting the new configuration with the given leader.
-    pub skip_prepare_use_leader: Option<Leader<R>>,
+    /// Metadata for the reconfiguration. Can be used for pre-electing leader for the new configuration and skip prepare phase when starting the new configuration with the given leader.
+    pub metadata: Option<Vec<u8>>,
 }
 
-impl<R> StopSign<R>
-where
-    R: Round,
-{
+impl StopSign {
     /// Creates a [`StopSign`].
-    pub fn with(
-        config_id: u32,
-        nodes: Vec<u64>,
-        skip_prepare_use_leader: Option<Leader<R>>,
-    ) -> Self {
+    pub fn with(config_id: u32, nodes: Vec<u64>, metadata: Option<Vec<u8>>) -> Self {
         StopSign {
             config_id,
             nodes,
-            skip_prepare_use_leader,
+            metadata,
         }
     }
 }
 
-impl<R> PartialEq for StopSign<R>
-where
-    R: Round,
-{
+impl PartialEq for StopSign {
     fn eq(&self, other: &Self) -> bool {
         self.config_id == other.config_id && self.nodes == other.nodes
     }
 }
 
 /// Trait to implement a back-end for the log replicated by an Omni-Paxos replica.
-pub trait Sequence<R>
+pub trait Sequence<T>
 where
-    R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Creates an empty log.
     fn new() -> Self;
 
     /// Creates a log that is preloaded with the entries of `seq`.
-    fn new_with_sequence(seq: Vec<Entry<R>>) -> Self;
+    fn new_with_sequence(seq: Vec<Entry<T>>) -> Self;
 
     /// Appends an entry to the end of the log.
-    fn append_entry(&mut self, entry: Entry<R>);
+    fn append_entry(&mut self, entry: Entry<T>);
 
     /// Appends the entries of `seq` to the end of the log.
-    fn append_sequence(&mut self, seq: &mut Vec<Entry<R>>);
+    fn append_sequence(&mut self, seq: &mut Vec<Entry<T>>);
 
     /// Appends the entries of `seq` to the prefix from index `from_index` in the log.
-    fn append_on_prefix(&mut self, from_idx: u64, seq: &mut Vec<Entry<R>>);
+    fn append_on_prefix(&mut self, from_idx: u64, seq: &mut Vec<Entry<T>>);
 
     /// Returns the entries in the log in the index interval of [from, to)
-    fn get_entries(&self, from: u64, to: u64) -> &[Entry<R>];
+    fn get_entries(&self, from: u64, to: u64) -> &[Entry<T>];
 
     /// Returns the suffix of entries in the log from index `from`.
-    fn get_suffix(&self, from: u64) -> Vec<Entry<R>>;
+    fn get_suffix(&self, from: u64) -> Vec<Entry<T>>;
 
     /// Returns the current length of the log.
     fn get_sequence_len(&self) -> u64;
@@ -102,9 +89,10 @@ where
 }
 
 /// Trait to implement a back-end for the internal state used by an Omni-Paxos replica.
-pub trait PaxosState<R>
+pub trait PaxosState<R, T>
 where
     R: Round,
+    T: AsRef<u8> + Clone,
 {
     /// Creates an empty initial state.
     fn new() -> Self;
@@ -119,10 +107,10 @@ where
     fn set_accepted_round(&mut self, na: R);
 
     /// Stores the suffix from the maximum promise.
-    fn set_max_promise_sfx(&mut self, max_promise_sfx: Vec<Entry<R>>);
+    fn set_max_promise_sfx(&mut self, max_promise_sfx: Vec<Entry<T>>);
 
     /// Returns the stored suffix of the maximum promise. Since this is only used once by the leader in the Prepare phase, it is recommended to return the consumed value.
-    fn get_max_promise_sfx(&mut self) -> Vec<Entry<R>>;
+    fn get_max_promise_sfx(&mut self) -> Vec<Entry<T>>;
 
     /// Returns the latest round in which entries have been accepted.
     fn get_accepted_round(&self) -> R;
@@ -140,38 +128,40 @@ where
     fn get_gc_idx(&self) -> u64;
 }
 
-enum PaxosSequence<R, S>
+enum PaxosSequence<S, T>
 where
-    R: Round,
-    S: Sequence<R>,
+    S: Sequence<T>,
+    T: AsRef<u8> + Clone,
 {
     Active(S),
     Stopped(Arc<S>),
     None,
-    _Never(PhantomData<R>), // make cargo happy for unused type R
+    _Never(PhantomData<T>),
 }
 
 /// A storage back-end to be used for Omni-Paxos.
-pub struct Storage<R, S, P>
+pub(crate) struct Storage<R, S, T, P>
 where
     R: Round,
-    S: Sequence<R>,
-    P: PaxosState<R>,
+    S: Sequence<T>,
+    T: AsRef<u8> + Clone,
+    P: PaxosState<R, T>,
 {
-    sequence: PaxosSequence<R, S>,
+    sequence: PaxosSequence<S, T>,
     paxos_state: P,
     _round_type: PhantomData<R>, // make cargo happy for unused type R
 }
 
-impl<R, S, P> Storage<R, S, P>
+impl<R, S, T, P> Storage<R, S, T, P>
 where
     R: Round,
-    S: Sequence<R>,
-    P: PaxosState<R>,
+    S: Sequence<T>,
+    T: AsRef<u8> + Clone,
+    P: PaxosState<R, T>,
 {
     /// Creates a [`Storage`] back-end for Omni-Paxos.
     /// The storage is divided into a [`Sequence`] and [`PaxosState`] allows for the log and the state to use different implementations.
-    pub fn with(seq: S, paxos_state: P) -> Storage<R, S, P> {
+    pub fn with(seq: S, paxos_state: P) -> Storage<R, S, T, P> {
         let sequence = PaxosSequence::Active(seq);
         Storage {
             sequence,
@@ -181,7 +171,7 @@ where
     }
 
     /// Appends an entry to the end of the log.
-    pub fn append_entry(&mut self, entry: Entry<R>) -> u64 {
+    pub fn append_entry(&mut self, entry: Entry<T>) -> u64 {
         match &mut self.sequence {
             PaxosSequence::Active(s) => {
                 s.append_entry(entry);
@@ -195,7 +185,7 @@ where
     }
 
     /// Appends the entries of `seq` to the end of the log.
-    pub fn append_sequence(&mut self, seq: &mut Vec<Entry<R>>) -> u64 {
+    pub fn append_sequence(&mut self, seq: &mut Vec<Entry<T>>) -> u64 {
         match &mut self.sequence {
             PaxosSequence::Active(s) => {
                 s.append_sequence(seq);
@@ -209,25 +199,22 @@ where
     }
 
     /// Appends the entries of `seq` to the prefix from index `from_index` in the log.
-    pub fn append_on_prefix(&mut self, from_idx: u64, seq: &mut Vec<Entry<R>>) -> u64 {
+    pub fn append_on_prefix(&mut self, from_idx: u64, seq: &mut Vec<Entry<T>>) -> u64 {
         match &mut self.sequence {
             PaxosSequence::Active(s) => {
                 s.append_on_prefix(from_idx, seq);
                 s.get_sequence_len()
             }
             PaxosSequence::Stopped(s) => {
-                if &s.get_suffix(from_idx) != seq {
-                    panic!("Sequence should not be modified after reconfiguration");
-                } else {
-                    s.get_sequence_len()
-                }
+                assert!(seq.is_empty());
+                s.get_sequence_len()
             }
             _ => panic!("Got unexpected intermediate PaxosSequence::None"),
         }
     }
 
     /// Appends the entries of `seq` to the decided prefix in the log.
-    pub fn append_on_decided_prefix(&mut self, seq: Vec<Entry<R>>) {
+    pub fn append_on_decided_prefix(&mut self, seq: Vec<Entry<T>>) {
         let from_idx = self.get_decided_len();
         match &mut self.sequence {
             PaxosSequence::Active(s) => {
@@ -264,7 +251,7 @@ where
     }
 
     /// Returns the entries in the log in the index interval of [from, to)
-    pub fn get_entries(&self, from: u64, to: u64) -> &[Entry<R>] {
+    pub fn get_entries(&self, from: u64, to: u64) -> &[Entry<T>] {
         match &self.sequence {
             PaxosSequence::Active(s) => s.get_entries(from, to),
             PaxosSequence::Stopped(s) => s.get_entries(from, to),
@@ -287,7 +274,7 @@ where
     }
 
     /// Returns the suffix of entries in the log from index `from`.
-    pub fn get_suffix(&self, from: u64) -> Vec<Entry<R>> {
+    pub fn get_suffix(&self, from: u64) -> Vec<Entry<T>> {
         match self.sequence {
             PaxosSequence::Active(ref s) => s.get_suffix(from),
             PaxosSequence::Stopped(ref arc_s) => arc_s.get_suffix(from),
@@ -342,12 +329,12 @@ where
     }
 
     /// Stores the suffix from the maximum promise.
-    pub fn set_max_promise_sfx(&mut self, max_promise_sfx: Vec<Entry<R>>) {
+    pub fn set_max_promise_sfx(&mut self, max_promise_sfx: Vec<Entry<T>>) {
         self.paxos_state.set_max_promise_sfx(max_promise_sfx);
     }
 
     /// Returns the stored suffix of the maximum promise.
-    pub fn get_max_promise_sfx(&mut self) -> Vec<Entry<R>> {
+    pub fn get_max_promise_sfx(&mut self) -> Vec<Entry<T>> {
         self.paxos_state.get_max_promise_sfx()
     }
 }
@@ -361,40 +348,40 @@ pub mod memory_storage {
 
     /// Stores all the accepted entries inside a vector.
     #[derive(Debug)]
-    pub struct MemorySequence<R>
+    pub struct MemorySequence<T>
     where
-        R: Round,
+        T: AsRef<u8> + Clone,
     {
         /// Vector which contains all the logged entries in-memory.
-        sequence: Vec<Entry<R>>,
+        sequence: Vec<Entry<T>>,
     }
 
-    impl<R> Sequence<R> for MemorySequence<R>
+    impl<T> Sequence<T> for MemorySequence<T>
     where
-        R: Round,
+        T: AsRef<u8> + Clone,
     {
         fn new() -> Self {
             MemorySequence { sequence: vec![] }
         }
 
-        fn new_with_sequence(seq: Vec<Entry<R>>) -> Self {
+        fn new_with_sequence(seq: Vec<Entry<T>>) -> Self {
             MemorySequence { sequence: seq }
         }
 
-        fn append_entry(&mut self, entry: Entry<R>) {
+        fn append_entry(&mut self, entry: Entry<T>) {
             self.sequence.push(entry);
         }
 
-        fn append_sequence(&mut self, seq: &mut Vec<Entry<R>>) {
+        fn append_sequence(&mut self, seq: &mut Vec<Entry<T>>) {
             self.sequence.append(seq);
         }
 
-        fn append_on_prefix(&mut self, from_idx: u64, seq: &mut Vec<Entry<R>>) {
+        fn append_on_prefix(&mut self, from_idx: u64, seq: &mut Vec<Entry<T>>) {
             self.sequence.truncate(from_idx as usize);
             self.sequence.append(seq);
         }
 
-        fn get_entries(&self, from: u64, to: u64) -> &[Entry<R>] {
+        fn get_entries(&self, from: u64, to: u64) -> &[Entry<T>] {
             match self.sequence.get(from as usize..to as usize) {
                 Some(ents) => ents,
                 None => panic!(
@@ -406,7 +393,7 @@ pub mod memory_storage {
             }
         }
 
-        fn get_suffix(&self, from: u64) -> Vec<Entry<R>> {
+        fn get_suffix(&self, from: u64) -> Vec<Entry<T>> {
             match self.sequence.get(from as usize..) {
                 Some(s) => s.to_vec(),
                 None => vec![],
@@ -431,9 +418,10 @@ pub mod memory_storage {
 
     /// Stores the state of a paxos replica in-memory.
     #[derive(Debug)]
-    pub struct MemoryState<R>
+    pub struct MemoryState<R, T>
     where
         R: Round,
+        T: AsRef<u8> + Clone,
     {
         /// Last promised round.
         n_prom: R,
@@ -444,12 +432,13 @@ pub mod memory_storage {
         /// Garbage collected index.
         gc_idx: u64,
         /// Max promise suffix.
-        max_promise_sfx: Vec<Entry<R>>,
+        max_promise_sfx: Vec<Entry<T>>,
     }
 
-    impl<R> PaxosState<R> for MemoryState<R>
+    impl<R, T> PaxosState<R, T> for MemoryState<R, T>
     where
         R: Round,
+        T: AsRef<u8> + Clone,
     {
         fn new() -> Self {
             let r = R::default();
@@ -474,11 +463,11 @@ pub mod memory_storage {
             self.acc_round = na;
         }
 
-        fn set_max_promise_sfx(&mut self, max_promise_sfx: Vec<Entry<R>>) {
+        fn set_max_promise_sfx(&mut self, max_promise_sfx: Vec<Entry<T>>) {
             self.max_promise_sfx = max_promise_sfx;
         }
 
-        fn get_max_promise_sfx(&mut self) -> Vec<Entry<R>> {
+        fn get_max_promise_sfx(&mut self) -> Vec<Entry<T>> {
             std::mem::take(&mut self.max_promise_sfx)
         }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -140,11 +140,11 @@ where
 }
 
 /// A storage back-end to be used for Omni-Paxos.
-pub(crate) struct Storage<R, S, T, P>
+pub(crate) struct Storage<R, T, S, P>
 where
     R: Round,
-    S: Sequence<T>,
     T: AsRef<u8> + Clone,
+    S: Sequence<T>,
     P: PaxosState<R, T>,
 {
     sequence: PaxosSequence<S, T>,
@@ -152,16 +152,16 @@ where
     _round_type: PhantomData<R>, // make cargo happy for unused type R
 }
 
-impl<R, S, T, P> Storage<R, S, T, P>
+impl<R, T, S, P> Storage<R, T, S, P>
 where
     R: Round,
-    S: Sequence<T>,
     T: AsRef<u8> + Clone,
+    S: Sequence<T>,
     P: PaxosState<R, T>,
 {
     /// Creates a [`Storage`] back-end for Omni-Paxos.
     /// The storage is divided into a [`Sequence`] and [`PaxosState`] allows for the log and the state to use different implementations.
-    pub fn with(seq: S, paxos_state: P) -> Storage<R, S, T, P> {
+    pub fn with(seq: S, paxos_state: P) -> Storage<R, T, S, P> {
         let sequence = PaxosSequence::Active(seq);
         Storage {
             sequence,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,64 +1,51 @@
-use crate::leader_election::Round;
-use std::cmp::Ordering;
+use crate::leader_election::ballot_leader_election::Ballot;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
 /// Promise without the suffix
-pub(crate) struct PromiseMetaData<R>
-where
-    R: Round,
-{
-    pub n: R,
+pub(crate) struct PromiseMetaData {
+    pub n: Ballot,
     pub la: u64,
     pub pid: u64,
 }
 
-impl<R> PromiseMetaData<R>
-where
-    R: Round,
-{
-    pub fn with(n: R, la: u64, pid: u64) -> Self {
+impl PromiseMetaData {
+    pub fn with(n: Ballot, la: u64, pid: u64) -> Self {
         Self { n, la, pid }
     }
 }
 
-impl<R> Ord for PromiseMetaData<R>
-where
-    R: Round,
-{
-    fn cmp(&self, other: &Self) -> Ordering {
-        if self.n == other.n && self.la == other.la && self.pid == other.pid {
-            Ordering::Equal
-        } else if self.n > other.n && self.la > other.la {
-            Ordering::Greater
-        } else {
-            Ordering::Less
-        }
-    }
-}
+// impl Ord for PromiseMetaData
+// where
+//     R: Ballotound,
+// {
+//     fn cmp(&self, other: &Self) -> Ordering {
+//         if self.n == other.n && self.la == other.la && self.pid == other.pid {
+//             Ordering::Equal
+//         } else if self.n > other.n && self.la > other.la {
+//             Ordering::Greater
+//         } else {
+//             Ordering::Less
+//         }
+//     }
+// }
 
-impl<R> PartialOrd for PromiseMetaData<R>
-where
-    R: Round,
-{
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let ordering = if self.n == other.n && self.la == other.la && self.pid == other.pid {
-            Ordering::Equal
-        } else if self.n > other.n || (self.n == other.n && self.la > other.la) {
-            Ordering::Greater
-        } else {
-            Ordering::Less
-        };
-        Some(ordering)
-    }
-}
+// impl PartialOrd for PromiseMetaData
+// {
+//     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+//         let ordering = if self.n == other.n && self.la == other.la && self.pid == other.pid {
+//             Ordering::Equal
+//         } else if self.n > other.n || (self.n == other.n && self.la > other.la) {
+//             Ordering::Greater
+//         } else {
+//             Ordering::Less
+//         };
+//         Some(ordering)
+//     }
+// }
 
-impl<R> PartialEq for PromiseMetaData<R>
-where
-    R: Round,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.n == other.n && self.la == other.la && self.pid == other.pid
-    }
-}
-
-impl<R> Eq for PromiseMetaData<R> where R: Round {}
+// impl PartialEq for PromiseMetaData
+// {
+//     fn eq(&self, other: &Self) -> bool {
+//         self.n == other.n && self.la == other.la && self.pid == other.pid
+//     }
+// }

--- a/src/utils/hocon_kv.rs
+++ b/src/utils/hocon_kv.rs
@@ -2,6 +2,8 @@
 pub const CONFIG_ID: &str = "config_id";
 /// The identifier of this replica.
 pub const PID: &str = "pid";
+/// The priority of this replica
+pub const PRIORITY: &str = "priority";
 /// A fixed delay that is added to the current_delay. It is measured in ticks.
 pub const HB_DELAY: &str = "hb_delay";
 /// A factor used in the beginning for a shorter hb_delay.

--- a/tests/ble_test.rs
+++ b/tests/ble_test.rs
@@ -2,7 +2,7 @@ pub mod test_config;
 pub mod util;
 
 use kompact::prelude::{promise, Ask};
-use omnipaxos::leader_election::{ballot_leader_election::Ballot, Leader};
+use omnipaxos::leader_election::{ballot_leader_election::Ballot};
 use serial_test::serial;
 use test_config::TestConfig;
 use util::TestSystem;
@@ -22,7 +22,7 @@ fn ble_test() {
 
     let mut futures = vec![];
     for _ in 0..cfg.num_elections {
-        let (kprom, kfuture) = promise::<Leader<Ballot>>();
+        let (kprom, kfuture) = promise::<Ballot>();
         ble.on_definition(|x| x.add_ask(Ask::new(kprom, ())));
         futures.push(kfuture);
     }
@@ -33,7 +33,7 @@ fn ble_test() {
         let elected_leader = fr
             .wait_timeout(cfg.wait_timeout)
             .expect("No leader has been elected in the allocated time!");
-        println!("elected: {} {}", elected_leader.pid, elected_leader.round.n);
+        println!("elected: {:?}", elected_leader);
         sys.kill_node(elected_leader.pid);
     }
 

--- a/tests/ble_test.rs
+++ b/tests/ble_test.rs
@@ -2,7 +2,7 @@ pub mod test_config;
 pub mod util;
 
 use kompact::prelude::{promise, Ask};
-use omnipaxos::leader_election::{ballot_leader_election::Ballot};
+use omnipaxos::leader_election::ballot_leader_election::Ballot;
 use serial_test::serial;
 use test_config::TestConfig;
 use util::TestSystem;

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -2,10 +2,7 @@ pub mod test_config;
 pub mod util;
 
 use kompact::prelude::{promise, Ask, FutureCollection};
-use omnipaxos::{
-    leader_election::ballot_leader_election::Ballot,
-    storage::{Entry, Sequence},
-};
+use omnipaxos::storage::{Entry, Sequence};
 use serial_test::serial;
 use test_config::TestConfig;
 use util::TestSystem;

--- a/tests/gc_test.rs
+++ b/tests/gc_test.rs
@@ -2,10 +2,7 @@ pub mod test_config;
 pub mod util;
 
 use kompact::prelude::{promise, Ask, FutureCollection};
-use omnipaxos::{
-    leader_election::ballot_leader_election::Ballot,
-    storage::{Entry, Sequence},
-};
+use omnipaxos::storage::{Entry, Sequence};
 use serial_test::serial;
 use std::thread;
 use test_config::TestConfig;
@@ -134,11 +131,7 @@ fn double_gc_test() {
     };
 }
 
-fn check_gc(
-    vec_proposals: Vec<Entry<u64>>,
-    seq_after: Vec<(&u64, Vec<Entry<u64>>)>,
-    gc_idx: u64,
-) {
+fn check_gc(vec_proposals: Vec<Entry<u64>>, seq_after: Vec<(&u64, Vec<Entry<u64>>)>, gc_idx: u64) {
     for i in 0..seq_after.len() {
         let (_, after) = seq_after.get(i).expect("After Sequence");
 

--- a/tests/gc_test.rs
+++ b/tests/gc_test.rs
@@ -25,15 +25,13 @@ fn gc_test() {
 
     let (_, px) = sys.ble_paxos_nodes().get(&1).unwrap();
 
-    let mut vec_proposals: Vec<Entry<Ballot>> = vec![];
+    let mut vec_proposals: Vec<Entry<u64>> = vec![];
     let mut futures = vec![];
     for i in 0..cfg.num_proposals {
-        let (kprom, kfuture) = promise::<Entry<Ballot>>();
-        let prop = format!("Decide Paxos {}", i).as_bytes().to_vec();
-
-        vec_proposals.push(Entry::Normal(prop.clone()));
+        let (kprom, kfuture) = promise::<Entry<u64>>();
+        vec_proposals.push(Entry::Normal(i));
         px.on_definition(|x| {
-            x.propose(prop);
+            x.propose(i);
             x.add_ask(Ask::new(kprom, ()))
         });
         futures.push(kfuture);
@@ -52,7 +50,7 @@ fn gc_test() {
 
     thread::sleep(cfg.wait_timeout);
 
-    let mut seq_after: Vec<(&u64, Vec<Entry<Ballot>>)> = vec![];
+    let mut seq_after: Vec<(&u64, Vec<Entry<u64>>)> = vec![];
     for (i, (_, px)) in sys.ble_paxos_nodes() {
         seq_after.push(px.on_definition(|comp| {
             let seq = comp.stop_and_get_sequence();
@@ -82,15 +80,14 @@ fn double_gc_test() {
 
     let (_, px) = sys.ble_paxos_nodes().get(&1).unwrap();
 
-    let mut vec_proposals: Vec<Entry<Ballot>> = vec![];
+    let mut vec_proposals: Vec<Entry<u64>> = vec![];
     let mut futures = vec![];
     for i in 0..cfg.num_proposals {
-        let (kprom, kfuture) = promise::<Entry<Ballot>>();
-        let prop = format!("Decide Paxos {}", i).as_bytes().to_vec();
+        let (kprom, kfuture) = promise::<Entry<u64>>();
 
-        vec_proposals.push(Entry::Normal(prop.clone()));
+        vec_proposals.push(Entry::Normal(i));
         px.on_definition(|x| {
-            x.propose(prop);
+            x.propose(i);
             x.add_ask(Ask::new(kprom, ()))
         });
         futures.push(kfuture);
@@ -115,7 +112,7 @@ fn double_gc_test() {
 
     thread::sleep(cfg.wait_timeout);
 
-    let mut seq_after_double: Vec<(&u64, Vec<Entry<Ballot>>)> = vec![];
+    let mut seq_after_double: Vec<(&u64, Vec<Entry<u64>>)> = vec![];
     for (i, (_, px)) in sys.ble_paxos_nodes() {
         seq_after_double.push(px.on_definition(|comp| {
             let seq = comp.stop_and_get_sequence();
@@ -138,8 +135,8 @@ fn double_gc_test() {
 }
 
 fn check_gc(
-    vec_proposals: Vec<Entry<Ballot>>,
-    seq_after: Vec<(&u64, Vec<Entry<Ballot>>)>,
+    vec_proposals: Vec<Entry<u64>>,
+    seq_after: Vec<(&u64, Vec<Entry<u64>>)>,
     gc_idx: u64,
 ) {
     for i in 0..seq_after.len() {

--- a/tests/proposal_test.rs
+++ b/tests/proposal_test.rs
@@ -3,7 +3,7 @@ pub mod util;
 
 use kompact::prelude::{promise, Ask};
 use omnipaxos::{
-    leader_election::{ballot_leader_election::Ballot, Leader},
+    leader_election::{ballot_leader_election::Ballot},
     storage::Entry,
 };
 use rand::Rng;
@@ -22,7 +22,7 @@ fn forward_proposal_test() {
 
     let (ble, _) = sys.ble_paxos_nodes().get(&1).unwrap();
 
-    let (kprom_ble, kfuture_ble) = promise::<Leader<Ballot>>();
+    let (kprom_ble, kfuture_ble) = promise::<Ballot>();
     ble.on_definition(|x| x.add_ask(Ask::new(kprom_ble, ())));
 
     sys.start_all_nodes();
@@ -30,7 +30,7 @@ fn forward_proposal_test() {
     let elected_leader = kfuture_ble
         .wait_timeout(cfg.wait_timeout)
         .expect("No leader has been elected in the allocated time!");
-    println!("elected: {} {}", elected_leader.pid, elected_leader.round.n);
+    println!("elected: {:?}", elected_leader);
 
     let mut proposal_node: u64;
     loop {
@@ -43,10 +43,10 @@ fn forward_proposal_test() {
 
     let (_, px) = sys.ble_paxos_nodes().get(&proposal_node).unwrap();
 
-    let (kprom_px, kfuture_px) = promise::<Entry<Ballot>>();
+    let (kprom_px, kfuture_px) = promise::<Entry<u64>>();
     px.on_definition(|x| {
         x.add_ask(Ask::new(kprom_px, ()));
-        x.propose("Decide Paxos".as_bytes().to_vec());
+        x.propose(123);
     });
 
     kfuture_px

--- a/tests/proposal_test.rs
+++ b/tests/proposal_test.rs
@@ -2,10 +2,7 @@ pub mod test_config;
 pub mod util;
 
 use kompact::prelude::{promise, Ask};
-use omnipaxos::{
-    leader_election::{ballot_leader_election::Ballot},
-    storage::Entry,
-};
+use omnipaxos::{leader_election::ballot_leader_election::Ballot, storage::Entry};
 use rand::Rng;
 use serial_test::serial;
 use test_config::TestConfig;

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -63,8 +63,8 @@ impl TestSystem {
             // create components
             let (ble_comp, ble_reg_f) = system.create_and_register(|| {
                 BallotLeaderComp::with(BallotLeaderElection::with(
-                    peer_pids.clone(),
                     pid,
+                    peer_pids.clone(),
                     None,
                     ble_hb_delay,
                     ble_initial_leader,


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Issues
Fixes #29 and #6 

## Breaking Changes
- Added a type parameter `T` to `OmniPaxos<T, S, P>` which is the type that user proposes to be replicated in the log. This should make the library more user friendly since users can now propose and read their data type instead of having to de/serialize it into a `Vec<u8>`.  
- User can now provide an `Option<u64>` as a priority into BLE. 
- Added `metadata` parameter to `propose_reconfiguration()` that allows users to include some additional metadata when performing a reconfiguration. `metadata` is a `Vec<u8>` to avoid having too many type parameters in `OmniPaxos`. This is also fine since reconfiguration is called at most once.

This PR touched large parts of the repo but also made it cleaner and will allow further features to be developed such as Snapshots (#32).   