### PR TITLE
Snapshot and Log API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ latest_accepted = []
 latest_decide = []
 continued_leader_reconfiguration = []
 
-default = ["latest_accepted", "latest_decide", "continued_leader_reconfiguration"]
+default = ["latest_accepted", "latest_decide", "continued_leader_reconfiguration", "batch_accept"]
 
 [profile.release]
 lto = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! * `latest_decide` - Only send latest decided log index as all preceding entries are implicitly decided. Reduces message overhead.
 //! * `continued_leader_reconfiguration` - Let the cluster pick the current leader as the initial leader in the new configuration (if possible) to shorten down-time during reconfiguration.
 
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
 /// Trait and struct related to the leader election in Omni-Paxos.
 pub mod leader_election;
 /// The different messages Omni-Paxos replicas can communicate to each other with.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,6 @@ pub mod paxos;
 /// Traits and structs related to the backend storage of an Omni-Paxos replica.
 pub mod storage;
 /// A module containing helper functions and structs.
-mod util;
+pub mod util;
 /// Holds helpful functions for the user.
 pub mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //! * `latest_decide` - Only send latest decided log index as all preceding entries are implicitly decided. Reduces message overhead.
 //! * `continued_leader_reconfiguration` - Let the cluster pick the current leader as the initial leader in the new configuration (if possible) to shorten down-time during reconfiguration.
 
-// #![deny(missing_docs)]
+#![deny(missing_docs)]
 /// Trait and struct related to the leader election in Omni-Paxos.
 pub mod leader_election;
 /// The different messages Omni-Paxos replicas can communicate to each other with.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -234,6 +234,12 @@ impl DecideStopSign {
     }
 }
 
+#[derive(Clone, Debug)]
+pub enum Compaction {
+    Trim(Option<u64>),
+    Snapshot(u64),
+}
+
 /// An enum for all the different message types.
 #[allow(missing_docs)]
 #[derive(Clone, Debug)]
@@ -254,8 +260,8 @@ where
     Decide(Decide),
     /// Forward client proposals to the leader.
     ProposalForward(Vec<T>),
-    Trim(u64),
-    ForwardTrim(Option<u64>),
+    Compaction(Compaction),
+    ForwardCompaction(Compaction),
     AcceptStopSign(AcceptStopSign),
     AcceptedStopSign(AcceptedStopSign),
     DecideStopSign(DecideStopSign),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -3,6 +3,7 @@ use crate::{
     storage::{Snapshot, StopSign},
     util::SyncItem,
 };
+use std::fmt::Debug;
 
 /// Prepare message sent by a newly-elected leader to initiate the Prepare phase.
 #[derive(Copy, Clone, Debug)]
@@ -33,7 +34,7 @@ impl Prepare {
 #[derive(Clone, Debug)]
 pub struct Promise<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     /// The current round.
@@ -51,7 +52,7 @@ where
 
 impl<T, S> Promise<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     /// Creates a [`Promise`] message.
@@ -78,7 +79,7 @@ where
 #[derive(Clone, Debug)]
 pub struct AcceptSync<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     /// The current round.
@@ -93,7 +94,7 @@ where
 
 impl<T, S> AcceptSync<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     /// Creates an [`AcceptSync`] message.
@@ -118,7 +119,7 @@ where
 #[derive(Clone, Debug)]
 pub struct FirstAccept<T>
 where
-    T: Clone,
+    T: Clone + Debug,
 {
     /// The current round.
     pub n: Ballot,
@@ -128,7 +129,7 @@ where
 
 impl<T> FirstAccept<T>
 where
-    T: Clone,
+    T: Clone + Debug,
 {
     /// Creates a [`FirstAccept`] message.
     pub fn with(n: Ballot, entries: Vec<T>) -> Self {
@@ -140,7 +141,7 @@ where
 #[derive(Clone, Debug)]
 pub struct AcceptDecide<T>
 where
-    T: Clone,
+    T: Clone + Debug,
 {
     /// The current round.
     pub n: Ballot,
@@ -152,7 +153,7 @@ where
 
 impl<T> AcceptDecide<T>
 where
-    T: Clone,
+    T: Clone + Debug,
 {
     /// Creates an [`AcceptDecide`] message.
     pub fn with(n: Ballot, ld: u64, entries: Vec<T>) -> Self {
@@ -238,7 +239,7 @@ impl DecideStopSign {
 #[derive(Clone, Debug)]
 pub enum PaxosMsg<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     /// Request a [`Prepare`] to be sent from the leader. Used for fail-recovery.
@@ -264,7 +265,7 @@ where
 #[derive(Clone, Debug)]
 pub struct Message<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     /// Sender of `msg`.
@@ -277,7 +278,7 @@ where
 
 impl<T, S> Message<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     /// Creates a message.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -47,6 +47,7 @@ where
     pub ld: u64,
     /// The log length of this follower.
     pub la: u64,
+    /// The StopSign accepted by this follower
     pub stopsign: Option<StopSign>,
 }
 
@@ -86,9 +87,11 @@ where
     pub n: Ballot,
     /// Entries that the receiving replica is missing in its log.
     pub sync_item: SyncItem<T, S>,
-    /// The index of the log where `entries` should be applied at.
+    /// The index of the log where the entries from `sync_item` should be applied at or the compacted idx
     pub sync_idx: u64,
+    /// The decided index
     pub decide_idx: Option<u64>,
+    /// StopSign to be accepted
     pub stopsign: Option<StopSign>,
 }
 
@@ -193,6 +196,7 @@ impl Decide {
     }
 }
 
+/// Message sent by leader to followers to accept a StopSign
 #[derive(Clone, Debug)]
 pub struct AcceptStopSign {
     /// The current round.
@@ -208,6 +212,7 @@ impl AcceptStopSign {
     }
 }
 
+/// Message sent by followers to leader when accepted StopSign
 #[derive(Copy, Clone, Debug)]
 pub struct AcceptedStopSign {
     /// The current round.
@@ -221,6 +226,7 @@ impl AcceptedStopSign {
     }
 }
 
+/// Message sent by leader to decide a StopSign
 #[derive(Copy, Clone, Debug)]
 pub struct DecideStopSign {
     /// The current round.
@@ -234,6 +240,8 @@ impl DecideStopSign {
     }
 }
 
+/// Compaction Request
+#[allow(missing_docs)]
 #[derive(Clone, Debug)]
 pub enum Compaction {
     Trim(Option<u64>),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -254,8 +254,8 @@ where
     Decide(Decide),
     /// Forward client proposals to the leader.
     ProposalForward(Vec<T>),
-    GarbageCollect(u64),
-    ForwardGarbageCollect(Option<u64>),
+    Trim(u64),
+    ForwardTrim(Option<u64>),
     AcceptStopSign(AcceptStopSign),
     AcceptedStopSign(AcceptedStopSign),
     DecideStopSign(DecideStopSign),

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,6 +1,6 @@
 use crate::{
     leader_election::ballot_leader_election::Ballot,
-    storage::{Entry, Snapshot, SnapshotType, StopSign},
+    storage::{Snapshot, SnapshotType, StopSign},
 };
 use std::marker::PhantomData;
 
@@ -40,7 +40,7 @@ where
     /// The latest round in which an entry was accepted.
     pub n_accepted: Ballot,
     /// The suffix of missing entries at the leader.
-    pub sfx: Vec<Entry<T>>,
+    pub sfx: Vec<T>,
     /// The decided index of this follower.
     pub ld: u64,
     /// The log length of this follower.
@@ -56,7 +56,7 @@ where
     pub fn with(
         n: Ballot,
         n_accepted: Ballot,
-        sfx: Vec<Entry<T>>,
+        sfx: Vec<T>,
         ld: u64,
         la: u64,
         stop_sign: Option<StopSign>,
@@ -127,7 +127,7 @@ where
     /// The current round.
     pub n: Ballot,
     /// Entries that the receiving replica is missing in its log.
-    pub entries: Vec<Entry<T>>,
+    pub entries: Vec<T>,
     /// The index of the log where `entries` should be applied at.
     pub sync_idx: u64,
     pub decide_idx: Option<u64>,
@@ -138,7 +138,7 @@ where
     T: Clone,
 {
     /// Creates an [`AcceptSync`] message.
-    pub fn with(n: Ballot, sfx: Vec<Entry<T>>, sync_idx: u64, decide_idx: Option<u64>) -> Self {
+    pub fn with(n: Ballot, sfx: Vec<T>, sync_idx: u64, decide_idx: Option<u64>) -> Self {
         AcceptSync {
             n,
             entries: sfx,
@@ -189,7 +189,7 @@ where
     /// The current round.
     pub n: Ballot,
     /// Entries to be replicated.
-    pub entries: Vec<Entry<T>>,
+    pub entries: Vec<T>,
 }
 
 impl<T> FirstAccept<T>
@@ -197,7 +197,7 @@ where
     T: Clone,
 {
     /// Creates a [`FirstAccept`] message.
-    pub fn with(n: Ballot, entries: Vec<Entry<T>>) -> Self {
+    pub fn with(n: Ballot, entries: Vec<T>) -> Self {
         FirstAccept { n, entries }
     }
 }
@@ -213,7 +213,7 @@ where
     /// The decided index.
     pub ld: u64,
     /// Entries to be replicated.
-    pub entries: Vec<Entry<T>>,
+    pub entries: Vec<T>,
 }
 
 impl<T> AcceptDecide<T>
@@ -221,7 +221,7 @@ where
     T: Clone,
 {
     /// Creates an [`AcceptDecide`] message.
-    pub fn with(n: Ballot, ld: u64, entries: Vec<Entry<T>>) -> Self {
+    pub fn with(n: Ballot, ld: u64, entries: Vec<T>) -> Self {
         AcceptDecide { n, ld, entries }
     }
 }
@@ -266,7 +266,7 @@ where
     T: Clone,
     S: Snapshot<T>,
 {
-    /// Ballotequest a [`Prepare`] to be sent from the leader. Used for fail-recovery.
+    /// Request a [`Prepare`] to be sent from the leader. Used for fail-recovery.
     PrepareReq,
     #[allow(missing_docs)]
     Prepare(Prepare),
@@ -279,9 +279,10 @@ where
     Accepted(Accepted),
     Decide(Decide),
     /// Forward client proposals to the leader.
-    ProposalForward(Vec<Entry<T>>),
+    ProposalForward(Vec<T>),
     GarbageCollect(u64),
     ForwardGarbageCollect(Option<u64>),
+
 }
 
 /// A struct for a Paxos message that also includes sender and receiver.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -46,7 +46,7 @@ where
     pub ld: u64,
     /// The log length of this follower.
     pub la: u64,
-    pub stop_sign: Option<StopSign>,
+    pub stopsign: Option<StopSign>,
 }
 
 impl<T, S> Promise<T, S>
@@ -61,7 +61,7 @@ where
         sync_item: Option<SyncItem<T, S>>,
         ld: u64,
         la: u64,
-        stop_sign: Option<StopSign>,
+        stopsign: Option<StopSign>,
     ) -> Self {
         Self {
             n,
@@ -69,7 +69,7 @@ where
             sync_item,
             ld,
             la,
-            stop_sign,
+            stopsign,
         }
     }
 }
@@ -88,6 +88,7 @@ where
     /// The index of the log where `entries` should be applied at.
     pub sync_idx: u64,
     pub decide_idx: Option<u64>,
+    pub stopsign: Option<StopSign>,
 }
 
 impl<T, S> AcceptSync<T, S>
@@ -101,12 +102,14 @@ where
         sync_item: SyncItem<T, S>,
         sync_idx: u64,
         decide_idx: Option<u64>,
+        stopsign: Option<StopSign>,
     ) -> Self {
         AcceptSync {
             n,
             sync_item,
             sync_idx,
             decide_idx,
+            stopsign,
         }
     }
 }
@@ -189,6 +192,47 @@ impl Decide {
     }
 }
 
+#[derive(Clone, Debug)]
+pub struct AcceptStopSign {
+    /// The current round.
+    pub n: Ballot,
+    /// The decided index.
+    pub ss: StopSign,
+}
+
+impl AcceptStopSign {
+    /// Creates a [`AcceptStopSign`] message.
+    pub fn with(n: Ballot, ss: StopSign) -> Self {
+        AcceptStopSign { n, ss }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct AcceptedStopSign {
+    /// The current round.
+    pub n: Ballot,
+}
+
+impl AcceptedStopSign {
+    /// Creates a [`AcceptedStopSign`] message.
+    pub fn with(n: Ballot) -> Self {
+        AcceptedStopSign { n }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct DecideStopSign {
+    /// The current round.
+    pub n: Ballot,
+}
+
+impl DecideStopSign {
+    /// Creates a [`DecideStopSign`] message.
+    pub fn with(n: Ballot) -> Self {
+        DecideStopSign { n }
+    }
+}
+
 /// An enum for all the different message types.
 #[allow(missing_docs)]
 #[derive(Clone, Debug)]
@@ -211,6 +255,9 @@ where
     ProposalForward(Vec<T>),
     GarbageCollect(u64),
     ForwardGarbageCollect(Option<u64>),
+    AcceptStopSign(AcceptStopSign),
+    AcceptedStopSign(AcceptedStopSign),
+    DecideStopSign(DecideStopSign),
 }
 
 /// A struct for a Paxos message that also includes sender and receiver.
@@ -222,7 +269,7 @@ where
 {
     /// Sender of `msg`.
     pub from: u64,
-    /// Balloteceiver of `msg`.
+    /// Receiver of `msg`.
     pub to: u64,
     /// The message content.
     pub msg: PaxosMsg<T, S>,

--- a/src/paxos.rs
+++ b/src/paxos.rs
@@ -60,7 +60,7 @@ where
     outgoing: Vec<Message<T, S>>,
     /// Logger used to output the status of the component.
     logger: Logger,
-    cached_gc_index: u64,
+    cached_trim_index: u64,
     leader_state: LeaderState<T, S>,
     latest_accepted_meta: Option<(Ballot, usize)>,
     s: PhantomData<S>,
@@ -140,7 +140,7 @@ where
             prev_ld: 0,
             outgoing: Vec::with_capacity(BUFFER_SIZE),
             logger: l,
-            cached_gc_index: 0,
+            cached_trim_index: 0,
             leader_state: LeaderState::with(n_leader, lds, max_pid, majority),
             latest_accepted_meta: None,
             s: PhantomData,
@@ -180,18 +180,18 @@ where
         )
     }
 
-    /// Initiates the garbage collection process.
+    /// Initiates the trim process.
     /// # Arguments
     /// * `index` - Deletes all entries up to [`index`], if the [`index`] is None then the minimum index accepted by **ALL** servers will be used as the [`index`].
-    pub fn garbage_collect(&mut self, index: Option<u64>) {
+    pub fn trim(&mut self, index: Option<u64>) {
         match self.state {
-            (Role::Leader, _) => self.gc_prepare(index),
-            _ => self.forward_gc_request(index),
+            (Role::Leader, _) => self.trim_prepare(index),
+            _ => self.forward_trim_request(index),
         }
     }
 
-    /// Return garbage collection index from storage.
-    pub fn get_garbage_collected_idx(&self) -> u64 {
+    /// Return trim index from storage.
+    pub fn get_trimmed_idx(&self) -> u64 {
         self.storage.get_trimmed_idx()
     }
 
@@ -204,16 +204,16 @@ where
         }
     }
 
-    fn gc_prepare(&mut self, index: Option<u64>) {
+    fn trim_prepare(&mut self, index: Option<u64>) {
         let min_all_accepted_idx = self.leader_state.get_min_all_accepted_idx();
-        let gc_idx = match index {
+        let trim_idx = match index {
             Some(idx) => {
-                if (min_all_accepted_idx < &idx) || (idx < self.cached_gc_index) {
+                if (min_all_accepted_idx < &idx) || (idx < self.cached_trim_index) {
                     warn!(
                         self.logger,
-                        "Invalid garbage collector index: {:?}, cached_index: {}, las: {:?}",
+                        "Invalid trim index: {:?}, cached_index: {}, las: {:?}",
                         index,
-                        self.cached_gc_index,
+                        self.cached_trim_index,
                         self.leader_state.las
                     );
                     return;
@@ -223,37 +223,34 @@ where
             None => {
                 trace!(
                     self.logger,
-                    "No garbage collector index provided, using min_las_index: {:?}",
+                    "No trim index provided, using min_las_index: {:?}",
                     min_all_accepted_idx
                 );
                 *min_all_accepted_idx
             }
         };
         for pid in &self.peers {
-            self.outgoing.push(Message::with(
-                self.pid,
-                *pid,
-                PaxosMsg::GarbageCollect(gc_idx),
-            ));
+            self.outgoing
+                .push(Message::with(self.pid, *pid, PaxosMsg::Trim(trim_idx)));
         }
-        self.gc(gc_idx);
+        self.trim_log(trim_idx);
     }
 
-    fn gc(&mut self, index: u64) {
+    fn trim_log(&mut self, index: u64) {
         let decided_len = self.storage.get_decided_len();
         if decided_len < index {
             crit!(
                 self.logger,
-                "Received invalid garbage collection index! index: {:?}, prev_ld {}",
+                "Received invalid trim index! index: {:?}, prev_ld {}",
                 index,
                 decided_len
             );
             return;
         }
-        trace!(self.logger, "Garbage Collection index: {:?}", index);
-        self.storage.trim(index - self.cached_gc_index);
+        trace!(self.logger, "trim index: {:?}", index);
+        self.storage.trim(index - self.cached_trim_index);
         self.storage.set_trimmed_idx(index);
-        self.cached_gc_index = index;
+        self.cached_trim_index = index;
     }
 
     /// Returns the id of the current leader.
@@ -285,8 +282,8 @@ where
         let ld = self.storage.get_decided_len();
         if self.prev_ld < ld {
             let decided = self.storage.get_entries(
-                self.prev_ld - self.cached_gc_index,
-                ld - self.cached_gc_index,
+                self.prev_ld - self.cached_trim_index,
+                ld - self.cached_trim_index,
             );
             self.prev_ld = ld;
             decided
@@ -298,7 +295,7 @@ where
     /// Returns the entire decided entries of this replica.
     pub fn get_decided_entries(&self) -> &[T] {
         self.storage
-            .get_entries(0, self.storage.get_decided_len() - self.cached_gc_index)
+            .get_entries(0, self.storage.get_decided_len() - self.cached_trim_index)
     }
 
     /// Handle an incoming message.
@@ -317,8 +314,8 @@ where
             PaxosMsg::Accepted(accepted) => self.handle_accepted(accepted, m.from),
             PaxosMsg::Decide(d) => self.handle_decide(d),
             PaxosMsg::ProposalForward(proposals) => self.handle_forwarded_proposal(proposals),
-            PaxosMsg::GarbageCollect(index) => self.gc(index),
-            PaxosMsg::ForwardGarbageCollect(index) => self.handle_forwarded_gc_request(index),
+            PaxosMsg::Trim(index) => self.trim_log(index),
+            PaxosMsg::ForwardTrim(index) => self.handle_forwarded_trim_request(index),
             PaxosMsg::AcceptStopSign(acc_ss) => self.handle_accept_stopsign(acc_ss),
             PaxosMsg::AcceptedStopSign(acc_ss) => self.handle_accepted_stopsign(acc_ss, m.from),
             PaxosMsg::DecideStopSign(d_ss) => self.handle_decide_stopsign(d_ss),
@@ -401,8 +398,8 @@ where
         } else {
             self.storage
                 .get_entries(
-                    from_idx - self.cached_gc_index,
-                    to_idx - self.cached_gc_index,
+                    from_idx - self.cached_trim_index,
+                    to_idx - self.cached_trim_index,
                 )
                 .to_vec()
         }
@@ -505,15 +502,15 @@ where
         }
     }
 
-    fn forward_gc_request(&mut self, index: Option<u64>) {
+    fn forward_trim_request(&mut self, index: Option<u64>) {
         if self.leader > 0 && self.leader != self.pid {
             trace!(
                 self.logger,
-                "Forwarding gc request to Leader {}, index {:?}",
+                "Forwarding trim request to Leader {}, index {:?}",
                 self.leader,
                 index
             );
-            let pf = PaxosMsg::ForwardGarbageCollect(index);
+            let pf = PaxosMsg::ForwardTrim(index);
             let msg = Message::with(self.pid, self.leader, pf);
             self.outgoing.push(msg);
         }
@@ -530,15 +527,15 @@ where
         }
     }
 
-    fn handle_forwarded_gc_request(&mut self, index: Option<u64>) {
+    fn handle_forwarded_trim_request(&mut self, index: Option<u64>) {
         trace!(
             self.logger,
-            "Incoming Forwarded GC Request, index: {:?}",
+            "Incoming Forwarded trim Request, index: {:?}",
             index
         );
         match self.state {
-            (Role::Leader, _) => self.gc_prepare(index),
-            _ => self.forward_gc_request(index),
+            (Role::Leader, _) => self.trim_prepare(index),
+            _ => self.forward_trim_request(index),
         }
     }
 
@@ -709,7 +706,7 @@ where
             let (sfx, sync_idx) = if (promise_n == max_promise_n) && (promise_la < max_la) {
                 let sfx = self
                     .storage
-                    .get_suffix(*promise_la - self.cached_gc_index)
+                    .get_suffix(*promise_la - self.cached_trim_index)
                     .to_vec();
                 (sfx, *promise_la)
             } else {
@@ -717,7 +714,10 @@ where
                     .leader_state
                     .get_decided_idx(*pid)
                     .expect("Received PromiseMetaData but not found in ld");
-                let sfx = self.storage.get_suffix(ld - self.cached_gc_index).to_vec();
+                let sfx = self
+                    .storage
+                    .get_suffix(ld - self.cached_trim_index)
+                    .to_vec();
                 (sfx, ld)
             };
             let acc_sync = AcceptSync::with(
@@ -754,7 +754,7 @@ where
         // TODO use and_then
         self.storage.set_snapshot(snapshot);
         self.storage.set_trimmed_idx(trimmed_idx);
-        self.cached_gc_index = trimmed_idx;
+        self.cached_trim_index = trimmed_idx;
     }
 
     fn merge_pending_proposals_with_snapshot(&mut self) {
@@ -877,7 +877,7 @@ where
                 };
                 let sfx = self
                     .storage
-                    .get_suffix(sync_idx - self.cached_gc_index)
+                    .get_suffix(sync_idx - self.cached_trim_index)
                     .to_vec();
                 // inform what got decided already
                 let ld = if self.leader_state.get_chosen_idx() > 0 {
@@ -981,7 +981,7 @@ where
         // TODO use and_then
         self.storage.set_snapshot(snapshot.clone());
         self.storage.set_trimmed_idx(trim_idx);
-        self.cached_gc_index = trim_idx;
+        self.cached_trim_index = trim_idx;
         (trim_idx, snapshot)
     }
 
@@ -1029,13 +1029,13 @@ where
                 let (sync_item, stopsign) = if na > prep.n_accepted {
                     let entries = self
                         .storage
-                        .get_suffix(prep.ld - self.cached_gc_index)
+                        .get_suffix(prep.ld - self.cached_trim_index)
                         .to_vec();
                     (Some(SyncItem::Entries(entries)), self.get_stopsign())
                 } else if na == prep.n_accepted && la > prep.la {
                     let entries = self
                         .storage
-                        .get_suffix(prep.la - self.cached_gc_index)
+                        .get_suffix(prep.la - self.cached_trim_index)
                         .to_vec();
                     (Some(SyncItem::Entries(entries)), self.get_stopsign())
                 } else {
@@ -1069,7 +1069,7 @@ where
                             // TODO use and_then
                             self.storage.set_snapshot(c);
                             self.storage.set_trimmed_idx(accsync.sync_idx);
-                            self.cached_gc_index = accsync.sync_idx;
+                            self.cached_trim_index = accsync.sync_idx;
                         }
                         SnapshotType::Delta(d) => {
                             self.merge_snapshot(accsync.sync_idx, d);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -60,8 +60,6 @@ where
 {
     fn create(entries: &[T]) -> Self;
 
-    //fn create_delta(&self, other: Self) -> Self    // TODO create delta snapshot that can be merged() with other to become self.
-
     fn merge(&mut self, delta: Self);
 
     fn snapshottable() -> bool; // TODO: somehow check if user is using snapshots statically?
@@ -69,21 +67,6 @@ where
     //fn size_hint() -> u64;  // TODO: To let the system know trade-off of using entries vs snapshot?
 }
 
-/*pub struct LogEntry<T> where T: Clone
-{
-    data: T,
-    decided: bool,
-}
-
-impl<T> LogEntry<T> where
-    T: Clone + Debug,
-{
-    pub fn with(data: T, decided: bool) -> Self {
-        Self { data, decided }
-    }
-}*/
-
-// TODO create an internal storage struct that calls these user provided functions to hide logic from user e.g. stopped()
 // TODO return Result and use and_then in paxos
 pub trait Storage<T, S>
 where

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::leader_election::ballot_leader_election::Ballot;
-use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+use std::fmt::Debug;
 
 /// An entry in the replicated log.
 #[derive(Clone, Debug, PartialEq)]
@@ -51,47 +51,26 @@ impl PartialEq for StopSign {
     }
 }
 
-/// Trait to implement a back-end for the log replicated by an Omni-Paxos replica.
-pub trait Log<T>
+pub trait Snapshot<T>: Clone
 where
     T: Clone,
 {
-    /// Creates an empty log.
-    fn new() -> Self;
-
-    /// Creates a log that is preloaded with the entries of `log`.
-    fn with(log: Vec<Entry<T>>) -> Self;
-
-    /// Appends an entry to the end of the log.
-    fn append_entry(&mut self, entry: Entry<T>);
-
-    /// Appends the entries of `log` to the end of the log.
-    fn append_entries(&mut self, log: &mut Vec<Entry<T>>);
-
-    /// Appends the entries of `log` to the prefix from index `from_index` in the log.
-    fn append_on_prefix(&mut self, from_idx: u64, log: &mut Vec<Entry<T>>);
-
-    /// Returns the entries in the log in the index interval of [from, to)
-    fn get_entries(&self, from: u64, to: u64) -> &[Entry<T>];
-
-    /// Returns the suffix of entries in the log from index `from`.
-    fn get_suffix(&self, from: u64) -> Vec<Entry<T>>;
-
-    /// Returns the current length of the log.
-    fn get_len(&self) -> u64;
-
-    /// Returns true if the log contains a StopSign or a StopSign already has been decided.
-    /// Note that the log could have a StopSign that later gets overwritten, and thus this function might first return true and later false.
-    fn stopped(&self) -> bool;
-
-    /// Removes elements up to the given [`idx`] from storage.
-    fn garbage_collect(&mut self, idx: u64);
+    fn create(entries: &Vec<T>) -> Self;
 }
 
-/// Trait to implement a back-end for the internal state used by an Omni-Paxos replica.
-pub trait PaxosState {
-    /// Creates an empty initial state.
-    fn new() -> Self;
+pub trait Storage<T, S>
+where
+    T: Clone,
+    S: Snapshot<T>,
+{
+    /// Appends an entry to the end of the log and returns the log length.
+    fn append_entry(&mut self, entry: Entry<T>) -> u64;
+
+    /// Appends the entries of `entries` to the end of the log and returns the log length.
+    fn append_entries(&mut self, entries: &mut Vec<Entry<T>>) -> u64;
+
+    /// Appends the entries of `entries` to the prefix from index `from_index` in the log and returns the log length.
+    fn append_on_prefix(&mut self, from_idx: u64, entries: &mut Vec<Entry<T>>) -> u64;
 
     /// Sets the round that has been promised.
     fn set_promise(&mut self, nprom: Ballot);
@@ -99,259 +78,105 @@ pub trait PaxosState {
     /// Sets the decided index in the log.
     fn set_decided_len(&mut self, ld: u64);
 
+    fn get_decided_len(&self) -> u64;
+
     /// Sets the latest accepted round.
     fn set_accepted_round(&mut self, na: Ballot);
 
     /// Returns the latest round in which entries have been accepted.
     fn get_accepted_round(&self) -> Ballot;
 
-    /// Returns the index in the log that has been decided up to.
-    fn get_decided_len(&self) -> u64;
+    /// Returns the entries in the log in the index interval of [from, to)
+    fn get_entries(&self, from: u64, to: u64) -> &[Entry<T>];
+
+    /// Returns the current length of the log.
+    fn get_log_len(&self) -> u64;
+
+    /// Returns the suffix of entries in the log from index `from`.
+    fn get_suffix(&self, from: u64) -> Vec<Entry<T>>;
 
     /// Returns the round that has been promised.
     fn get_promise(&self) -> Ballot;
 
-    /// Sets the garbage collected index.
-    fn set_gc_idx(&mut self, index: u64);
-
-    /// Returns the garbage collected index.
-    fn get_gc_idx(&self) -> u64;
-}
-
-enum PaxosLog<L, T>
-where
-    L: Log<T>,
-    T: Clone,
-{
-    Active(L),
-    Stopped(Arc<L>),
-    None,
-    _Never(PhantomData<T>),
-}
-
-/// A storage back-end to be used for Omni-Paxos.
-pub(crate) struct Storage<T, L, P>
-where
-    T: Clone,
-    L: Log<T>,
-    P: PaxosState,
-{
-    log: PaxosLog<L, T>,
-    paxos_state: P,
-}
-
-impl<T, L, P> Storage<T, L, P>
-where
-    T: Clone,
-    L: Log<T>,
-    P: PaxosState,
-{
-    /// Creates a [`Storage`] back-end for Omni-Paxos.
-    /// The storage is divided into a [`Log`] and [`PaxosState`] allows for the log and the state to use different implementations.
-    pub fn with(log: L, paxos_state: P) -> Storage<T, L, P> {
-        let log = PaxosLog::Active(log);
-        Storage { log, paxos_state }
-    }
-
-    /// Appends an entry to the end of the log.
-    pub fn append_entry(&mut self, entry: Entry<T>) -> u64 {
-        match &mut self.log {
-            PaxosLog::Active(s) => {
-                s.append_entry(entry);
-                s.get_len()
-            }
-            PaxosLog::Stopped(_) => {
-                panic!("Log should not be modified after reconfiguration");
-            }
-            _ => panic!("Got unexpected intermediate PaxosLog::None"),
-        }
-    }
-
-    /// Appends the entries of `log` to the end of the log.
-    pub fn append_entries(&mut self, log: &mut Vec<Entry<T>>) -> u64 {
-        match &mut self.log {
-            PaxosLog::Active(s) => {
-                s.append_entries(log);
-                s.get_len()
-            }
-            PaxosLog::Stopped(_) => {
-                panic!("Log should not be modified after reconfiguration");
-            }
-            _ => panic!("Got unexpected intermediate PaxosLog::None"),
-        }
-    }
-
-    /// Appends the entries of `log` to the prefix from index `from_index` in the log.
-    pub fn append_on_prefix(&mut self, from_idx: u64, log: &mut Vec<Entry<T>>) -> u64 {
-        match &mut self.log {
-            PaxosLog::Active(s) => {
-                s.append_on_prefix(from_idx, log);
-                s.get_len()
-            }
-            PaxosLog::Stopped(s) => {
-                assert!(log.is_empty());
-                s.get_len()
-            }
-            _ => panic!("Got unexpected intermediate PaxosLog::None"),
-        }
-    }
-
-    /// Appends the entries of `log` to the decided prefix in the log.
-    pub fn append_on_decided_prefix(&mut self, log: Vec<Entry<T>>) {
-        let from_idx = self.get_decided_len();
-        match &mut self.log {
-            PaxosLog::Active(s) => {
-                let mut log = log;
-                s.append_on_prefix(from_idx, &mut log);
-            }
-            PaxosLog::Stopped(_) => {
-                if !log.is_empty() {
-                    panic!("Log should not be modified after reconfiguration");
-                }
-            }
-            _ => panic!("Got unexpected intermediate PaxosLog::None"),
-        }
-    }
-
-    /// Sets the round that has been promised.
-    pub fn set_promise(&mut self, nprom: Ballot) {
-        self.paxos_state.set_promise(nprom);
-    }
-
-    /// Sets the decided index in the log.
-    pub fn set_decided_len(&mut self, ld: u64) {
-        self.paxos_state.set_decided_len(ld);
-    }
-
-    /// Sets the latest accepted round.
-    pub fn set_accepted_round(&mut self, na: Ballot) {
-        self.paxos_state.set_accepted_round(na);
-    }
-
-    /// Returns the latest round in which entries have been accepted.
-    pub fn get_accepted_round(&self) -> Ballot {
-        self.paxos_state.get_accepted_round()
-    }
-
-    /// Returns the entries in the log in the index interval of [from, to)
-    pub fn get_entries(&self, from: u64, to: u64) -> &[Entry<T>] {
-        match &self.log {
-            PaxosLog::Active(s) => s.get_entries(from, to),
-            PaxosLog::Stopped(s) => s.get_entries(from, to),
-            _ => panic!("Got unexpected intermediate PaxosLog::None in get_entries"),
-        }
-    }
-
-    /// Returns the current length of the log.
-    pub fn get_log_len(&self) -> u64 {
-        match self.log {
-            PaxosLog::Active(ref s) => s.get_len(),
-            PaxosLog::Stopped(ref arc_s) => arc_s.get_len(),
-            _ => panic!("Got unexpected intermediate PaxosLog::None in get_log_len"),
-        }
-    }
-
-    /// Returns the index in the log that has been decided up to.
-    pub fn get_decided_len(&self) -> u64 {
-        self.paxos_state.get_decided_len()
-    }
-
-    /// Returns the suffix of entries in the log from index `from`.
-    pub fn get_suffix(&self, from: u64) -> Vec<Entry<T>> {
-        match self.log {
-            PaxosLog::Active(ref s) => s.get_suffix(from),
-            PaxosLog::Stopped(ref arc_s) => arc_s.get_suffix(from),
-            _ => panic!("Got unexpected intermediate PaxosLog::None in get_suffix"),
-        }
-    }
-
-    /// Returns the round that has been promised.
-    pub fn get_promise(&self) -> Ballot {
-        self.paxos_state.get_promise()
-    }
-
-    /// Returns true if the log contains a StopSign or a StopSign already has been decided.
-    /// Note that the log could have a StopSign that later gets overwritten, and thus this function might first return true and later false.
-    pub fn stopped(&self) -> bool {
-        match self.log {
-            PaxosLog::Active(ref s) => s.stopped(),
-            PaxosLog::Stopped(_) => true,
-            _ => panic!("Got unexpected intermediate PaxosLog::None in stopped()"),
-        }
-    }
-
-    /// Stops any new writes to the log and returns the whole log as an [`Arc`]. This should **only be used when a [`StopSign`]
-    /// i.e. a reconfiguration has been **decided.
-    pub fn stop_and_get_log(&mut self) -> Arc<L> {
-        let a = std::mem::replace(&mut self.log, PaxosLog::None);
-        match a {
-            PaxosLog::Active(s) => {
-                let arc_s = Arc::from(s);
-                self.log = PaxosLog::Stopped(arc_s.clone());
-                arc_s
-            }
-            _ => panic!("Storage should already have been stopped!"),
-        }
-    }
+    fn stopped(&self) -> bool;
 
     /// Removes elements up to the given [`idx`] from storage.
-    pub fn garbage_collect(&mut self, idx: u64) {
-        match self.log {
-            PaxosLog::Active(ref mut s) => {
-                s.garbage_collect(idx - self.paxos_state.get_gc_idx());
-                self.paxos_state.set_gc_idx(idx);
-            }
-            PaxosLog::Stopped(_) => {} // todo what to do when paxos is stopped?
-            _ => panic!("Got unexpected intermediate PaxosLog::None in stopped()"),
-        }
-    }
+    fn trim(&mut self, idx: u64);
 
     /// Returns the garbage collector index from storage.
-    pub fn get_gc_idx(&self) -> u64 {
-        self.paxos_state.get_gc_idx()
-    }
+    fn get_trim_idx(&self) -> u64;
+
+    fn set_snapshot(&mut self, snapshot: S) -> Result<(), ()>;
+
+    fn get_snapshot(&self) -> Option<S>;
 }
 
 /// An in-memory storage implementation for Paxos.
 pub mod memory_storage {
     use crate::{
         leader_election::ballot_leader_election::Ballot,
-        storage::{Entry, Log, PaxosState},
+        storage::{Entry, Snapshot, Storage},
     };
 
-    /// Stores all the accepted entries inside a vector.
-    #[derive(Debug)]
-    pub struct MemoryLog<T>
+    #[derive(Clone)]
+    pub struct MemoryStorage<T, S>
     where
         T: Clone,
+        S: Snapshot<T>,
     {
         /// Vector which contains all the logged entries in-memory.
         log: Vec<Entry<T>>,
+        /// Last promised round.
+        n_prom: Ballot,
+        /// Last accepted round.
+        acc_round: Ballot,
+        /// Length of the decided log.
+        ld: u64,
+        /// Garbage collected index.
+        gc_idx: u64,
+        // TODO index?
+        snapshot: S,
     }
 
-    impl<T> Log<T> for MemoryLog<T>
+    impl<T, S> Storage<T, S> for MemoryStorage<T, S>
     where
         T: Clone,
+        S: Snapshot<T>,
     {
-        fn new() -> Self {
-            MemoryLog { log: vec![] }
-        }
-
-        fn with(log: Vec<Entry<T>>) -> Self {
-            MemoryLog { log }
-        }
-
-        fn append_entry(&mut self, entry: Entry<T>) {
+        fn append_entry(&mut self, entry: Entry<T>) -> u64 {
             self.log.push(entry);
+            self.get_decided_len()
         }
 
-        fn append_entries(&mut self, entries: &mut Vec<Entry<T>>) {
+        fn append_entries(&mut self, entries: &mut Vec<Entry<T>>) -> u64 {
             self.log.append(entries);
+            self.get_decided_len()
         }
 
-        fn append_on_prefix(&mut self, from_idx: u64, log: &mut Vec<Entry<T>>) {
+        fn append_on_prefix(&mut self, from_idx: u64, entries: &mut Vec<Entry<T>>) -> u64 {
             self.log.truncate(from_idx as usize);
-            self.log.append(log);
+            self.log.append(entries);
+            self.get_decided_len()
+        }
+
+        fn set_promise(&mut self, n_prom: Ballot) {
+            self.n_prom = n_prom;
+        }
+
+        fn set_decided_len(&mut self, ld: u64) {
+            self.ld = ld;
+        }
+
+        fn get_decided_len(&self) -> u64 {
+            self.ld
+        }
+
+        fn set_accepted_round(&mut self, na: Ballot) {
+            self.acc_round = na;
+        }
+
+        fn get_accepted_round(&self) -> Ballot {
+            self.acc_round
         }
 
         fn get_entries(&self, from: u64, to: u64) -> &[Entry<T>] {
@@ -366,6 +191,10 @@ pub mod memory_storage {
             }
         }
 
+        fn get_log_len(&self) -> u64 {
+            self.log.len() as u64
+        }
+
         fn get_suffix(&self, from: u64) -> Vec<Entry<T>> {
             match self.log.get(from as usize..) {
                 Some(s) => s.to_vec(),
@@ -373,76 +202,28 @@ pub mod memory_storage {
             }
         }
 
-        fn get_len(&self) -> u64 {
-            self.log.len() as u64
-        }
-
-        fn stopped(&self) -> bool {
-            match self.log.last() {
-                Some(entry) => entry.is_stopsign(),
-                None => false,
-            }
-        }
-
-        fn garbage_collect(&mut self, idx: u64) {
-            self.log.drain(0..idx as usize);
-        }
-    }
-
-    /// Stores the state of a paxos replica in-memory.
-    #[derive(Debug)]
-    pub struct MemoryState {
-        /// Last promised round.
-        n_prom: Ballot,
-        /// Last accepted round.
-        acc_round: Ballot,
-        /// Length of the decided log.
-        ld: u64,
-        /// Garbage collected index.
-        gc_idx: u64,
-    }
-
-    impl PaxosState for MemoryState {
-        fn new() -> Self {
-            let r = Ballot::default();
-            MemoryState {
-                n_prom: r,
-                acc_round: r,
-                ld: 0,
-                gc_idx: 0,
-            }
-        }
-
-        fn set_promise(&mut self, n_prom: Ballot) {
-            self.n_prom = n_prom;
-        }
-
-        fn set_decided_len(&mut self, ld: u64) {
-            self.ld = ld;
-        }
-
-        fn set_accepted_round(&mut self, na: Ballot) {
-            self.acc_round = na;
-        }
-
-        fn get_accepted_round(&self) -> Ballot {
-            self.acc_round
-        }
-
-        fn get_decided_len(&self) -> u64 {
-            self.ld
-        }
-
         fn get_promise(&self) -> Ballot {
             self.n_prom
         }
 
-        fn set_gc_idx(&mut self, index: u64) {
-            self.gc_idx = index;
+        fn stopped(&self) -> bool {
+            todo!()
         }
 
-        fn get_gc_idx(&self) -> u64 {
-            self.gc_idx
+        fn trim(&mut self, idx: u64) {
+            todo!()
+        }
+
+        fn get_trim_idx(&self) -> u64 {
+            todo!()
+        }
+
+        fn set_snapshot(&mut self, snapshot: S) -> Result<(), ()> {
+            todo!()
+        }
+
+        fn get_snapshot(&self) -> Option<S> {
+            todo!()
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -113,12 +113,12 @@ where
     fn get_stopsign(&self) -> Option<StopSignEntry>;
 
     /// Removes elements up to the given [`idx`] from storage.
-    fn trim(&mut self, trimmed_idx: u64);
+    fn trim(&mut self, idx: u64);
 
-    fn set_trimmed_idx(&mut self, trimmed_idx: u64);
+    fn set_compacted_idx(&mut self, idx: u64);
 
     /// Returns the garbage collector index from storage.
-    fn get_trimmed_idx(&self) -> u64;
+    fn get_compacted_idx(&self) -> u64;
 
     fn set_snapshot(&mut self, snapshot: S);
 
@@ -197,15 +197,7 @@ pub mod memory_storage {
         }
 
         fn get_entries(&self, from: u64, to: u64) -> &[T] {
-            match self.log.get(from as usize..to as usize) {
-                Some(ents) => ents,
-                None => panic!(
-                    "get_entries out of bounds. From: {}, To: {}, len: {}",
-                    from,
-                    to,
-                    self.log.len()
-                ),
-            }
+            self.log.get(from as usize..to as usize).unwrap_or(&[])
         }
 
         fn get_log_len(&self) -> u64 {
@@ -235,11 +227,11 @@ pub mod memory_storage {
             self.log.drain(0..trimmed_idx as usize);
         }
 
-        fn set_trimmed_idx(&mut self, trimmed_idx: u64) {
+        fn set_compacted_idx(&mut self, trimmed_idx: u64) {
             self.trimmed_idx = trimmed_idx;
         }
 
-        fn get_trimmed_idx(&self) -> u64 {
+        fn get_compacted_idx(&self) -> u64 {
             self.trimmed_idx
         }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use crate::{
     messages::Promise,
     storage::{Snapshot, SnapshotType, StopSign},
 };
-use std::cmp::Ordering;
+use std::{cmp::Ordering, fmt::Debug};
 
 #[derive(Debug, Clone, Default)]
 /// Promise without the suffix
@@ -47,7 +47,7 @@ impl PartialEq for PromiseMetaData {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct LeaderState<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     pub n_leader: Ballot,
@@ -66,7 +66,7 @@ where
 
 impl<T, S> LeaderState<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     pub fn with(
@@ -208,7 +208,7 @@ where
 #[derive(Debug, Clone)]
 pub enum SyncItem<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     Entries(Vec<T>),
@@ -218,7 +218,7 @@ where
 
 impl<T, S> Default for SyncItem<T, S>
 where
-    T: Clone,
+    T: Clone + Debug,
     S: Snapshot<T>,
 {
     fn default() -> Self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,19 +1,45 @@
 use crate::{
     leader_election::ballot_leader_election::Ballot,
-    storage::{Snapshot, SnapshotType},
+    storage::{Snapshot, SnapshotType, StopSign},
 };
+use std::cmp::Ordering;
 
-#[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Debug, Clone)]
 /// Promise without the suffix
 pub(crate) struct PromiseMetaData {
     pub n: Ballot,
     pub la: u64,
     pub pid: u64,
+    pub stopsign: Option<StopSign>,
 }
 
 impl PromiseMetaData {
-    pub fn with(n: Ballot, la: u64, pid: u64) -> Self {
-        Self { n, la, pid }
+    pub fn with(n: Ballot, la: u64, pid: u64, stopsign: Option<StopSign>) -> Self {
+        Self {
+            n,
+            la,
+            pid,
+            stopsign,
+        }
+    }
+}
+
+impl PartialOrd for PromiseMetaData {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        let ordering = if self.n == other.n && self.la == other.la && self.pid == other.pid {
+            Ordering::Equal
+        } else if self.n > other.n || (self.n == other.n && self.la > other.la) {
+            Ordering::Greater
+        } else {
+            Ordering::Less
+        };
+        Some(ordering)
+    }
+}
+
+impl PartialEq for PromiseMetaData {
+    fn eq(&self, other: &Self) -> bool {
+        self.n == other.n && self.la == other.la && self.pid == other.pid
     }
 }
 
@@ -27,39 +53,3 @@ where
     Snapshot(SnapshotType<T, S>),
     None,
 }
-
-// impl Ord for PromiseMetaData
-// where
-//     R: Ballotound,
-// {
-//     fn cmp(&self, other: &Self) -> Ordering {
-//         if self.n == other.n && self.la == other.la && self.pid == other.pid {
-//             Ordering::Equal
-//         } else if self.n > other.n && self.la > other.la {
-//             Ordering::Greater
-//         } else {
-//             Ordering::Less
-//         }
-//     }
-// }
-
-// impl PartialOrd for PromiseMetaData
-// {
-//     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-//         let ordering = if self.n == other.n && self.la == other.la && self.pid == other.pid {
-//             Ordering::Equal
-//         } else if self.n > other.n || (self.n == other.n && self.la > other.la) {
-//             Ordering::Greater
-//         } else {
-//             Ordering::Less
-//         };
-//         Some(ordering)
-//     }
-// }
-
-// impl PartialEq for PromiseMetaData
-// {
-//     fn eq(&self, other: &Self) -> bool {
-//         self.n == other.n && self.la == other.la && self.pid == other.pid
-//     }
-// }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use crate::{
     leader_election::ballot_leader_election::Ballot,
-    storage::{Entry, Snapshot, SnapshotType},
+    storage::{Snapshot, SnapshotType},
 };
 
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
@@ -22,7 +22,7 @@ where
     T: Clone,
     S: Snapshot<T>,
 {
-    Entries(Vec<Entry<T>>),
+    Entries(Vec<T>),
     Snapshot(SnapshotType<T, S>),
     None,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,7 @@
-use crate::leader_election::ballot_leader_election::Ballot;
+use crate::{
+    leader_election::ballot_leader_election::Ballot,
+    storage::{Entry, Snapshot, SnapshotType},
+};
 
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
 /// Promise without the suffix
@@ -12,6 +15,16 @@ impl PromiseMetaData {
     pub fn with(n: Ballot, la: u64, pid: u64) -> Self {
         Self { n, la, pid }
     }
+}
+
+pub enum PromiseType<T, S>
+where
+    T: Clone,
+    S: Snapshot<T>,
+{
+    Entries(Vec<Entry<T>>),
+    Snapshot(SnapshotType<T, S>),
+    None,
 }
 
 // impl Ord for PromiseMetaData

--- a/src/util.rs
+++ b/src/util.rs
@@ -233,3 +233,24 @@ where
         SyncItem::None
     }
 }
+
+#[derive(Debug, Clone)]
+pub enum LogEntry<'a, T, S>
+where
+    T: Clone + Debug,
+    S: Snapshot<T>,
+{
+    Decided(&'a T),
+    Undecided(&'a T),
+    Trimmed(u64),
+    Snapshotted(u64, S),
+    StopSign(StopSign),
+    None,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum LogEntryType {
+    Entry,
+    Compacted,
+    StopSign(StopSign),
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,11 @@
 use crate::{
     leader_election::ballot_leader_election::Ballot,
+    messages::Promise,
     storage::{Snapshot, SnapshotType, StopSign},
 };
 use std::cmp::Ordering;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 /// Promise without the suffix
 pub(crate) struct PromiseMetaData {
     pub n: Ballot,
@@ -43,6 +44,167 @@ impl PartialEq for PromiseMetaData {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LeaderState<T, S>
+where
+    T: Clone,
+    S: Snapshot<T>,
+{
+    pub n_leader: Ballot,
+    pub promises_meta: Vec<Option<PromiseMetaData>>,
+    pub las: Vec<u64>,
+    pub lds: Vec<Option<u64>>,
+    pub lc: u64, // length of longest chosen seq
+    pub max_promise_meta: PromiseMetaData,
+    pub max_promise: SyncItem<T, S>,
+    pub batch_accept_meta: Vec<Option<(Ballot, usize)>>, //  index in outgoing
+    pub latest_decide_meta: Vec<Option<(Ballot, usize)>>,
+    pub accepted_stopsign: Vec<bool>,
+    pub max_pid: usize,
+    pub majority: usize,
+}
+
+impl<T, S> LeaderState<T, S>
+where
+    T: Clone,
+    S: Snapshot<T>,
+{
+    pub fn with(
+        n_leader: Ballot,
+        lds: Option<Vec<Option<u64>>>,
+        max_pid: usize,
+        majority: usize,
+    ) -> Self {
+        Self {
+            n_leader,
+            promises_meta: vec![None; max_pid + 1],
+            las: vec![0; max_pid + 1],
+            lds: lds.unwrap_or(vec![None; max_pid + 1]),
+            lc: 0,
+            max_promise_meta: PromiseMetaData::default(),
+            max_promise: SyncItem::None,
+            batch_accept_meta: vec![None; max_pid + 1],
+            latest_decide_meta: vec![None; max_pid + 1],
+            accepted_stopsign: vec![false; max_pid + 1],
+            max_pid,
+            majority,
+        }
+    }
+
+    pub fn set_decided_idx(&mut self, pid: u64, idx: Option<u64>) {
+        self.lds[pid as usize] = idx;
+    }
+
+    pub fn set_promise(&mut self, prom: Promise<T, S>, from: u64) -> bool {
+        let promise_meta = PromiseMetaData::with(prom.n_accepted, prom.la, from, prom.stopsign);
+        if promise_meta > self.max_promise_meta {
+            self.max_promise_meta = promise_meta.clone();
+            self.max_promise = prom.sync_item.unwrap_or(SyncItem::None); // TODO: this should be fine?
+        }
+        self.lds[from as usize] = Some(prom.ld);
+        self.promises_meta[from as usize] = Some(promise_meta);
+        let num_promised = self.promises_meta.iter().filter(|x| x.is_some()).count();
+        num_promised >= self.majority
+    }
+
+    pub fn take_max_promise(&mut self) -> SyncItem<T, S> {
+        std::mem::take(&mut self.max_promise)
+    }
+
+    pub fn get_max_promise_meta(&self) -> &PromiseMetaData {
+        &self.max_promise_meta
+    }
+
+    pub fn set_accepted_stopsign(&mut self, from: u64) {
+        self.accepted_stopsign[from as usize] = true;
+    }
+
+    pub fn get_promise_meta(&self, pid: u64) -> &PromiseMetaData {
+        self.promises_meta[pid as usize]
+            .as_ref()
+            .expect("No Metadata found for promised follower")
+    }
+
+    pub fn get_min_all_accepted_idx(&self) -> Option<&u64> {
+        self.las.iter().min().clone()
+    }
+
+    pub fn reset_batch_accept_meta(&mut self) {
+        self.batch_accept_meta = vec![None; self.max_pid + 1];
+    }
+
+    pub fn reset_latest_decided_meta(&mut self) {
+        self.latest_decide_meta = vec![None; self.max_pid + 1];
+    }
+
+    pub fn set_chosen_idx(&mut self, idx: u64) {
+        self.lc = idx;
+    }
+
+    pub fn get_chosen_idx(&self) -> u64 {
+        self.lc
+    }
+
+    pub fn get_promised_followers(&self) -> Vec<u64> {
+        self.lds
+            .iter()
+            .enumerate()
+            .filter(|(pid, x)| x.is_some() && *pid != self.n_leader.pid as usize)
+            .map(|(idx, _)| idx as u64)
+            .collect()
+    }
+
+    pub fn set_batch_accept_meta(&mut self, pid: u64, idx: Option<usize>) {
+        let meta = idx.map(|x| (self.n_leader, x));
+        self.batch_accept_meta[pid as usize] = meta;
+    }
+
+    pub fn set_latest_decide_meta(&mut self, pid: u64, idx: Option<usize>) {
+        let meta = idx.map(|x| (self.n_leader, x));
+        self.latest_decide_meta[pid as usize] = meta;
+    }
+
+    pub fn set_accepted_idx(&mut self, pid: u64, idx: u64) {
+        self.las[pid as usize] = idx;
+    }
+
+    pub fn get_batch_accept_meta(&self, pid: u64) -> Option<(Ballot, usize)> {
+        self.batch_accept_meta
+            .get(pid as usize)
+            .unwrap()
+            .as_ref()
+            .copied()
+    }
+    pub fn get_latest_decide_meta(&self, pid: u64) -> Option<(Ballot, usize)> {
+        self.latest_decide_meta
+            .get(pid as usize)
+            .unwrap()
+            .as_ref()
+            .copied()
+    }
+
+    pub fn get_decided_idx(&self, pid: u64) -> &Option<u64> {
+        self.lds.get(pid as usize).unwrap()
+    }
+
+    pub fn is_stopsign_chosen(&self) -> bool {
+        let num_accepted = self
+            .accepted_stopsign
+            .iter()
+            .filter(|x| **x == true)
+            .count();
+        num_accepted >= self.majority
+    }
+
+    pub fn is_chosen(&self, idx: u64) -> bool {
+        self.las.iter().filter(|la| **la >= idx).count() >= self.majority
+    }
+
+    pub fn take_max_promise_stopsign(&mut self) -> Option<StopSign> {
+        self.max_promise_meta.stopsign.take()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum SyncItem<T, S>
 where
@@ -52,4 +214,14 @@ where
     Entries(Vec<T>),
     Snapshot(SnapshotType<T, S>),
     None,
+}
+
+impl<T, S> Default for SyncItem<T, S>
+where
+    T: Clone,
+    S: Snapshot<T>,
+{
+    fn default() -> Self {
+        SyncItem::None
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,7 +17,8 @@ impl PromiseMetaData {
     }
 }
 
-pub enum PromiseType<T, S>
+#[derive(Debug, Clone)]
+pub enum SyncItem<T, S>
 where
     T: Clone,
     S: Snapshot<T>,

--- a/tests/config/test.conf
+++ b/tests/config/test.conf
@@ -8,9 +8,9 @@ ble_test {
 }
 
 consensus_test {
-    wait_timeout: 2 s
+    wait_timeout: 3 s
     num_threads: 8
-    num_nodes: 20
+    num_nodes: 3
     ble_hb_delay: 5
     increment_delay: 2
     num_proposals: 20

--- a/tests/consensus_test.rs
+++ b/tests/consensus_test.rs
@@ -1,7 +1,13 @@
 pub mod test_config;
 pub mod util;
 
+use crate::util::LatestValue;
 use kompact::prelude::{promise, Ask, FutureCollection};
+use omnipaxos::{
+    paxos::OmniPaxos,
+    storage::{memory_storage::MemoryStorage, Snapshot, StopSign, StopSignEntry, Storage},
+    util::LogEntry,
+};
 use serial_test::serial;
 use test_config::TestConfig;
 use util::TestSystem;
@@ -55,6 +61,171 @@ fn consensus_test() {
     };
 }
 
+#[test]
+fn read_test() {
+    let log = vec![1, 3, 2, 7, 5, 10, 29, 100, 8, 12];
+    let decided_idx = 6;
+    let snapshotted_idx: u64 = 4;
+    let (snapshotted, _suffix) = log.split_at(snapshotted_idx as usize);
+
+    let exp_snapshot = LatestValue::create(snapshotted);
+
+    let mut mem_storage = MemoryStorage::<u64, LatestValue>::default();
+    mem_storage.append_entries(log.clone());
+    mem_storage.set_decided_len(decided_idx);
+
+    let mut op = OmniPaxos::with(1, 1, vec![1, 2, 3], mem_storage, None, None, None);
+    op.snapshot(Some(snapshotted_idx), true);
+
+    // read entries only
+    let from_idx = snapshotted_idx + 1;
+    let to_idx = decided_idx + 1;
+    let entries = op.read_entries(from_idx, to_idx).expect("No entries");
+    let expected_entries = log.get(from_idx as usize..to_idx as usize).unwrap();
+    verify_entries(entries.as_slice(), expected_entries, from_idx, decided_idx);
+
+    // read snapshot only
+    let entries = op.read_entries(0, snapshotted_idx).expect("No snapshot");
+    verify_snapshot(entries.as_slice(), snapshotted_idx, &exp_snapshot);
+
+    // read snapshot + entries
+    let from_idx = 3;
+    let to_idx = decided_idx;
+    let entries = op
+        .read_entries(from_idx, to_idx)
+        .expect("No snapshot and entries");
+    let (snapshot, suffix) = entries.split_at(1);
+    let expected_entries = log.get(snapshotted_idx as usize..to_idx as usize).unwrap();
+    verify_snapshot(snapshot, snapshotted_idx, &exp_snapshot);
+    verify_entries(suffix, expected_entries, snapshotted_idx, decided_idx);
+
+    // create stopped storage and OmniPaxos to test reading StopSign.
+    let mut stopped_storage = MemoryStorage::<u64, LatestValue>::default();
+    let ss = StopSign::with(2, vec![], None);
+    let log_len = log.len() as u64;
+    stopped_storage.append_entries(log.clone());
+    stopped_storage.set_stopsign(StopSignEntry::with(ss.clone(), true));
+    stopped_storage.set_decided_len(log_len);
+
+    let mut stopped_op = OmniPaxos::with(1, 1, vec![1, 2, 3], stopped_storage, None, None, None);
+    stopped_op.snapshot(Some(snapshotted_idx), true);
+
+    // read stopsign only
+    let from_idx = log_len;
+    let to_idx = log_len + 1;
+    let entries = stopped_op
+        .read_entries(from_idx, to_idx)
+        .expect("No StopSign");
+    verify_stopsign(entries.as_slice(), &ss);
+
+    // read entries + stopsign
+    let from_idx = snapshotted_idx + 2;
+    let to_idx = log_len + 1;
+    let entries = stopped_op
+        .read_entries(from_idx, to_idx)
+        .expect("No StopSign and Entries");
+    let (prefix, stopsign) = entries.split_at(entries.len() - 1);
+    verify_entries(
+        prefix,
+        log.get(from_idx as usize..).unwrap(),
+        from_idx,
+        log_len,
+    );
+    verify_stopsign(stopsign, &ss);
+
+    // read snapshot + entries + stopsign
+    let from_idx = 0;
+    let to_idx = log_len + 1;
+    let entries = stopped_op
+        .read_entries(from_idx, to_idx)
+        .expect("No StopSign and Entries");
+    let (prefix, stopsign) = entries.split_at(entries.len() - 1);
+    let (snapshot, ents) = prefix.split_at(1);
+    verify_snapshot(snapshot, snapshotted_idx, &exp_snapshot);
+    verify_entries(
+        ents,
+        log.get(snapshotted_idx as usize..).unwrap(),
+        snapshotted_idx,
+        log_len,
+    );
+    verify_stopsign(stopsign, &ss);
+
+    // read snapshot + stopsign
+    // snapshot entire log
+    stopped_op.snapshot(Some(log_len), true);
+    let snapshotted_idx = log_len;
+    let from_idx = 0;
+    let to_idx = log_len + 1;
+    let entries = stopped_op
+        .read_entries(from_idx, to_idx)
+        .expect("No StopSign and Entries");
+    let (snapshot, stopsign) = entries.split_at(entries.len() - 1);
+    verify_snapshot(snapshot, snapshotted_idx, &LatestValue::create(&log));
+    verify_stopsign(stopsign, &ss);
+}
+
+fn verify_snapshot(
+    read_entries: &[LogEntry<u64, LatestValue>],
+    exp_compacted_idx: u64,
+    exp_snapshot: &LatestValue,
+) {
+    assert_eq!(read_entries.len(), 1);
+    match read_entries.first().unwrap() {
+        LogEntry::Snapshotted(idx, snapshot) => {
+            assert_eq!(*idx, exp_compacted_idx);
+            assert_eq!(snapshot, exp_snapshot);
+        }
+        e => {
+            panic!("{}", format!("Not a snapshot: {:?}", e))
+        }
+    }
+}
+
+fn verify_stopsign(read_entries: &[LogEntry<u64, LatestValue>], exp_stopsign: &StopSign) {
+    assert_eq!(
+        read_entries.len(),
+        1,
+        "Expected StopSign, read: {:?}",
+        read_entries
+    );
+    match read_entries.first().unwrap() {
+        LogEntry::StopSign(ss) => {
+            assert_eq!(ss, exp_stopsign);
+        }
+        e => {
+            panic!("{}", format!("Not a StopSign: {:?}", e))
+        }
+    }
+}
+
+fn verify_entries(
+    read_entries: &[LogEntry<u64, LatestValue>],
+    exp_entries: &[u64],
+    offset: u64,
+    decided_idx: u64,
+) {
+    assert_eq!(
+        read_entries.len(),
+        exp_entries.len(),
+        "read: {:?}, expected: {:?}",
+        read_entries,
+        exp_entries
+    );
+    for (idx, entry) in read_entries.iter().enumerate() {
+        let log_idx = idx as u64 + offset;
+        match entry {
+            LogEntry::Decided(i) if log_idx <= decided_idx => assert_eq!(**i, exp_entries[idx]),
+            LogEntry::Undecided(i) if log_idx > decided_idx => assert_eq!(**i, exp_entries[idx]),
+            e => panic!(
+                "{}",
+                format!(
+                    "Unexpected entry at idx {}: {:?}, decided_idx: {}",
+                    idx, e, decided_idx
+                )
+            ),
+        }
+    }
+}
 /// Verifies that there is a majority when an entry is proposed.
 fn check_quorum(log_responses: Vec<(&u64, Vec<u64>)>, quorum_size: usize, num_proposals: Vec<u64>) {
     for i in num_proposals {

--- a/tests/gc_test.rs
+++ b/tests/gc_test.rs
@@ -41,7 +41,7 @@ fn gc_test() {
     }
 
     px.on_definition(|x| {
-        x.garbage_collect(Some(cfg.gc_idx));
+        x.trim(Some(cfg.gc_idx));
     });
 
     thread::sleep(cfg.wait_timeout);
@@ -97,13 +97,13 @@ fn double_gc_test() {
     }
 
     px.on_definition(|x| {
-        x.garbage_collect(Some(cfg.gc_idx));
+        x.trim(Some(cfg.gc_idx));
     });
 
     thread::sleep(cfg.wait_timeout);
 
     px.on_definition(|x| {
-        x.garbage_collect(Some(cfg.gc_idx + GC_INDEX_INCREMENT));
+        x.trim(Some(cfg.gc_idx + GC_INDEX_INCREMENT));
     });
 
     thread::sleep(cfg.wait_timeout);

--- a/tests/gc_test.rs
+++ b/tests/gc_test.rs
@@ -49,7 +49,7 @@ fn gc_test() {
     let mut seq_after: Vec<(&u64, Vec<u64>)> = vec![];
     for (i, (_, px)) in sys.ble_paxos_nodes() {
         seq_after.push(px.on_definition(|comp| {
-            let seq = comp.get_log();
+            let seq = comp.get_trimmed_suffix();
             (i, seq.to_vec())
         }));
     }
@@ -111,7 +111,7 @@ fn double_gc_test() {
     let mut seq_after_double: Vec<(&u64, Vec<u64>)> = vec![];
     for (i, (_, px)) in sys.ble_paxos_nodes() {
         seq_after_double.push(px.on_definition(|comp| {
-            let seq = comp.get_log();
+            let seq = comp.get_trimmed_suffix();
             (i, seq.to_vec())
         }));
     }

--- a/tests/proposal_test.rs
+++ b/tests/proposal_test.rs
@@ -2,7 +2,7 @@ pub mod test_config;
 pub mod util;
 
 use kompact::prelude::{promise, Ask};
-use omnipaxos::{leader_election::ballot_leader_election::Ballot, storage::Entry};
+use omnipaxos::leader_election::ballot_leader_election::Ballot;
 use rand::Rng;
 use serial_test::serial;
 use test_config::TestConfig;
@@ -40,7 +40,7 @@ fn forward_proposal_test() {
 
     let (_, px) = sys.ble_paxos_nodes().get(&proposal_node).unwrap();
 
-    let (kprom_px, kfuture_px) = promise::<Entry<u64>>();
+    let (kprom_px, kfuture_px) = promise::<u64>();
     px.on_definition(|x| {
         x.add_ask(Ask::new(kprom_px, ()));
         x.propose(123);

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -361,7 +361,7 @@ pub mod omnireplica {
         }
 
         pub fn garbage_collect(&mut self, index: Option<u64>) {
-            self.paxos.garbage_collect(index)
+            self.paxos.trim(index)
         }
 
         fn answer_future(&mut self) {

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -7,6 +7,7 @@ use omnipaxos::{
     leader_election::ballot_leader_election::{messages::BLEMessage, Ballot, BallotLeaderElection},
     messages::Message,
     paxos::OmniPaxos,
+    storage::{memory_storage::MemoryStorage, Snapshot},
 };
 use std::{collections::HashMap, str, sync::Arc, time::Duration};
 
@@ -55,7 +56,7 @@ impl TestSystem {
 
         let all_pids: Vec<u64> = (1..=num_nodes as u64).collect();
         let mut ble_refs: HashMap<u64, ActorRef<BLEMessage>> = HashMap::new();
-        let mut omni_refs: HashMap<u64, ActorRef<Message<u64>>> = HashMap::new();
+        let mut omni_refs: HashMap<u64, ActorRef<Message<u64, LatestValue>>> = HashMap::new();
 
         for pid in 1..=num_nodes as u64 {
             let mut peer_pids = all_pids.clone();
@@ -75,7 +76,15 @@ impl TestSystem {
             });
 
             let (omni_replica, omni_reg_f) = system.create_and_register(|| {
-                OmniPaxosReplica::with(OmniPaxos::with(1, pid, peer_pids.clone(), None, None, None))
+                OmniPaxosReplica::with(OmniPaxos::with(
+                    1,
+                    pid,
+                    peer_pids.clone(),
+                    MemoryStorage::default(),
+                    None,
+                    None,
+                    None,
+                ))
             });
 
             biconnect_components::<BallotLeaderElectionPort, _, _>(&ble_comp, &omni_replica)
@@ -206,10 +215,8 @@ pub mod ble {
 
         fn send_outgoing_msgs(&mut self) {
             let outgoing = self.ble.get_outgoing_msgs();
-
             for out in outgoing {
                 let receiver = self.peers.get(&out.to).unwrap();
-
                 receiver.tell(out);
             }
         }
@@ -232,11 +239,9 @@ pub mod ble {
                     self.schedule_periodic(BLE_TIMER_TIMEOUT, BLE_TIMER_TIMEOUT, move |c, _| {
                         if let Some(l) = c.ble.tick() {
                             c.answer_future(l);
-
                             c.ble_port.trigger(l);
                         }
                         c.send_outgoing_msgs();
-
                         Handled::Ok
                     }),
                 );
@@ -276,13 +281,8 @@ pub mod ble {
 pub mod omnireplica {
     use super::{ble::BallotLeaderElectionPort, *};
     use omnipaxos::{
-        leader_election::ballot_leader_election::Ballot,
-        messages::Message,
-        paxos::OmniPaxos,
-        storage::{
-            memory_storage::{MemoryLog, MemoryState},
-            Entry,
-        },
+        leader_election::ballot_leader_election::Ballot, messages::Message, paxos::OmniPaxos,
+        storage::memory_storage::MemoryStorage,
     };
     use std::{
         collections::{HashMap, LinkedList},
@@ -293,10 +293,10 @@ pub mod omnireplica {
     pub struct OmniPaxosReplica {
         ctx: ComponentContext<Self>,
         ble_port: RequiredPort<BallotLeaderElectionPort>,
-        peers: HashMap<u64, ActorRef<Message<u64>>>,
+        peers: HashMap<u64, ActorRef<Message<u64, LatestValue>>>,
         timer: Option<ScheduledTimer>,
-        paxos: OmniPaxos<u64, MemoryLog<u64>, MemoryState>,
-        ask_vector: LinkedList<Ask<(), Entry<u64>>>,
+        paxos: OmniPaxos<u64, LatestValue, MemoryStorage<u64, LatestValue>>,
+        ask_vector: LinkedList<Ask<(), u64>>,
     }
 
     impl ComponentLifecycle for OmniPaxosReplica {
@@ -306,9 +306,7 @@ pub mod omnireplica {
                 Duration::from_millis(1),
                 move |c, _| {
                     c.send_outgoing_msgs();
-
                     c.answer_future();
-
                     Handled::Ok
                 },
             ));
@@ -325,7 +323,7 @@ pub mod omnireplica {
     }
 
     impl OmniPaxosReplica {
-        pub fn with(paxos: OmniPaxos<u64, MemoryLog<u64>, MemoryState>) -> Self {
+        pub fn with(paxos: OmniPaxos<u64, LatestValue, MemoryStorage<u64, LatestValue>>) -> Self {
             Self {
                 ctx: ComponentContext::uninitialised(),
                 ble_port: RequiredPort::uninitialised(),
@@ -336,12 +334,12 @@ pub mod omnireplica {
             }
         }
 
-        pub fn add_ask(&mut self, ask: Ask<(), Entry<u64>>) {
+        pub fn add_ask(&mut self, ask: Ask<(), u64>) {
             self.ask_vector.push_back(ask);
         }
 
-        pub fn stop_and_get_log(&mut self) -> Arc<MemoryLog<u64>> {
-            self.paxos.stop_and_get_log()
+        pub fn get_log(&self) -> &[u64] {
+            self.paxos.get_decided_entries()
         }
 
         fn send_outgoing_msgs(&mut self) {
@@ -354,7 +352,7 @@ pub mod omnireplica {
             }
         }
 
-        pub fn set_peers(&mut self, peers: HashMap<u64, ActorRef<Message<u64>>>) {
+        pub fn set_peers(&mut self, peers: HashMap<u64, ActorRef<Message<u64, LatestValue>>>) {
             self.peers = peers;
         }
 
@@ -379,7 +377,7 @@ pub mod omnireplica {
     }
 
     impl Actor for OmniPaxosReplica {
-        type Message = Message<u64>;
+        type Message = Message<u64, LatestValue>;
 
         fn receive_local(&mut self, msg: Self::Message) -> Handled {
             self.paxos.handle(msg);
@@ -396,5 +394,26 @@ pub mod omnireplica {
             self.paxos.handle_leader(l);
             Handled::Ok
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct LatestValue {
+    value: u64,
+}
+
+impl Snapshot<u64> for LatestValue {
+    fn create(entries: &[u64]) -> Self {
+        Self {
+            value: *entries.last().unwrap_or(&0u64),
+        }
+    }
+
+    fn merge(&mut self, delta: Self) {
+        self.value = delta.value;
+    }
+
+    fn snapshottable() -> bool {
+        true
     }
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -359,7 +359,7 @@ pub mod omnireplica {
         }
 
         pub fn propose(&mut self, data: u64) {
-            self.paxos.propose_normal(data).expect("Failed to propose!");
+            self.paxos.append(data).expect("Failed to propose!");
         }
 
         pub fn garbage_collect(&mut self, index: Option<u64>) {

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -343,7 +343,7 @@ pub mod omnireplica {
         pub fn get_trimmed_suffix(&self) -> Vec<u64> {
             if let Some(decided_ents) = self.paxos.read_decided_suffix(0) {
                 let ents = match decided_ents.first().unwrap() {
-                    LogEntry::Trimmed(_) | LogEntry::Snapshotted(_, _) => {
+                    LogEntry::Trimmed(_) | LogEntry::Snapshotted(_) => {
                         decided_ents.get(1..).unwrap()
                     }
                     _ => decided_ents.as_slice(),
@@ -377,8 +377,8 @@ pub mod omnireplica {
             self.paxos.append(data).expect("Failed to propose!");
         }
 
-        pub fn garbage_collect(&mut self, index: Option<u64>) {
-            self.paxos.trim(index)
+        pub fn trim(&mut self, index: Option<u64>) {
+            self.paxos.trim(index).expect("Failed to trim!");
         }
 
         fn answer_future(&mut self) {

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -397,7 +397,7 @@ pub mod omnireplica {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialOrd, PartialEq)]
 pub struct LatestValue {
     value: u64,
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -280,7 +280,7 @@ pub mod omnireplica {
         messages::Message,
         paxos::OmniPaxos,
         storage::{
-            memory_storage::{MemorySequence, MemoryState},
+            memory_storage::{MemoryLog, MemoryState},
             Entry,
         },
     };
@@ -295,7 +295,7 @@ pub mod omnireplica {
         ble_port: RequiredPort<BallotLeaderElectionPort>,
         peers: HashMap<u64, ActorRef<Message<u64>>>,
         timer: Option<ScheduledTimer>,
-        paxos: OmniPaxos<u64, MemorySequence<u64>, MemoryState>,
+        paxos: OmniPaxos<u64, MemoryLog<u64>, MemoryState>,
         ask_vector: LinkedList<Ask<(), Entry<u64>>>,
     }
 
@@ -325,7 +325,7 @@ pub mod omnireplica {
     }
 
     impl OmniPaxosReplica {
-        pub fn with(paxos: OmniPaxos<u64, MemorySequence<u64>, MemoryState>) -> Self {
+        pub fn with(paxos: OmniPaxos<u64, MemoryLog<u64>, MemoryState>) -> Self {
             Self {
                 ctx: ComponentContext::uninitialised(),
                 ble_port: RequiredPort::uninitialised(),
@@ -340,8 +340,8 @@ pub mod omnireplica {
             self.ask_vector.push_back(ask);
         }
 
-        pub fn stop_and_get_sequence(&mut self) -> Arc<MemorySequence<u64>> {
-            self.paxos.stop_and_get_sequence()
+        pub fn stop_and_get_log(&mut self) -> Arc<MemoryLog<u64>> {
+            self.paxos.stop_and_get_log()
         }
 
         fn send_outgoing_msgs(&mut self) {


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)

(OmniPaxos book will be updated when the async runtime (#36) is ready)

## Issues
Fixes #32, #34.

## Breaking Changes
The `FirstAccept` and forwarding of `StopSign` do not work currently due to the new way of deciding stopsigns (which is separated from the normal log replication). 

## Other Changes
- Added type parameter `S: Snapshot` to `OmniPaxos`. The trait `Snapshot` defines how snapshots are taken given some log entries.
- To support snapshots, the `Storage` trait is restructured such that the log only contains the user data `T`. The snapshots and stopsign is stored separately and not in the log.
- The prepare phase in `OmniPaxos` can use snapshots for log synchronization.
- Log API: `append()`, `read()`, `read_entries()`, `trim()` etc. replaces the old "conensus-style" API with `propose()` and `get_decided()` 
