### PR TITLE
fix: send stopsign at end of log

### DIFF
--- a/omnipaxos_core/src/sequence_paxos.rs
+++ b/omnipaxos_core/src/sequence_paxos.rs
@@ -263,9 +263,9 @@ where
         } else {
             let suffix_idx = idx - compacted_idx;
             let log_len = self.storage.get_log_len();
-            if suffix_idx >= log_len {
+            if suffix_idx > log_len {
                 match self.storage.get_stopsign() {
-                    Some(ss) if ss.decided && suffix_idx == log_len => {
+                    Some(ss) if ss.decided => {
                         Some(LogEntry::StopSign(ss.stopsign))
                     }
                     _ => None,


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Issues

The read function would not return the StopSign at the end of the log, I think this is because of a faulty comparison between the suffix_idx and log_len.

I believe the suffix_idx should always be larger than the log_len when we have a StopSign, and by forcing the suffix_idx to be equal to the log_len, we never get the StopSign.