### PR TITLE
Reconfiguration fixes

### DIFF
--- a/omnipaxos_core/src/messages.rs
+++ b/omnipaxos_core/src/messages.rs
@@ -273,6 +273,7 @@ where
     AcceptStopSign(AcceptStopSign),
     AcceptedStopSign(AcceptedStopSign),
     DecideStopSign(DecideStopSign),
+    ForwardStopSign(StopSign),
 }
 
 /// A struct for a Paxos message that also includes sender and receiver.

--- a/omnipaxos_core/src/messages.rs
+++ b/omnipaxos_core/src/messages.rs
@@ -120,23 +120,15 @@ where
 
 /// The first accept message sent. Only used by a pre-elected leader after reconfiguration.
 #[derive(Clone, Debug)]
-pub struct FirstAccept<T>
-where
-    T: Entry,
-{
+pub struct FirstAccept {
     /// The current round.
     pub n: Ballot,
-    /// Entries to be replicated.
-    pub entries: Vec<T>,
 }
 
-impl<T> FirstAccept<T>
-where
-    T: Entry,
-{
+impl FirstAccept {
     /// Creates a [`FirstAccept`] message.
-    pub fn with(n: Ballot, entries: Vec<T>) -> Self {
-        FirstAccept { n, entries }
+    pub fn with(n: Ballot) -> Self {
+        FirstAccept { n }
     }
 }
 
@@ -262,7 +254,7 @@ where
     Prepare(Prepare),
     Promise(Promise<T, S>),
     AcceptSync(AcceptSync<T, S>),
-    FirstAccept(FirstAccept<T>),
+    FirstAccept(FirstAccept),
     AcceptDecide(AcceptDecide<T>),
     Accepted(Accepted),
     Decide(Decide),

--- a/omnipaxos_core/src/sequence_paxos.rs
+++ b/omnipaxos_core/src/sequence_paxos.rs
@@ -436,8 +436,18 @@ where
         }
     }
 
+    /// Returns whether this Sequence Paxos has been reconfigured
+    pub fn is_reconfigured(&self) -> Option<StopSign> {
+        match self.storage.get_stopsign() {
+            Some(ss) if ss.decided => {
+                Some(ss.stopsign)
+            },
+            _ => None,
+        }
+    }
+
     /// Returns whether this Sequence Paxos instance is stopped, i.e. if it has been reconfigured.
-    pub fn stopped(&self) -> bool {
+    fn stopped(&self) -> bool {
         self.get_stopsign().is_some()
     }
 

--- a/omnipaxos_core/src/sequence_paxos.rs
+++ b/omnipaxos_core/src/sequence_paxos.rs
@@ -714,9 +714,15 @@ where
                         self.pending_stopsign = Some(ss);
                     }
                 }
-                (Role::Leader, Phase::Accept) => self.send_accept_stopsign(ss),
+                (Role::Leader, Phase::Accept) => {
+                    if self.pending_stopsign.is_none() {
+                        self.accept_stopsign(ss.clone());
+                        self.send_accept_stopsign(ss);
+                    }
+                }
                 (Role::Leader, Phase::FirstAccept) => {
                     self.send_first_accept();
+                    self.accept_stopsign(ss.clone());
                     self.send_accept_stopsign(ss);
                 }
                 _ => self.forward_stopsign(ss),

--- a/omnipaxos_core/src/sequence_paxos.rs
+++ b/omnipaxos_core/src/sequence_paxos.rs
@@ -244,10 +244,6 @@ where
         {
             self.leader_state.reset_batch_accept_meta();
         }
-        #[cfg(feature = "latest_decide")]
-        {
-            self.leader_state.reset_latest_decided_meta();
-        }
         #[cfg(feature = "latest_accepted")]
         {
             self.latest_accepted_meta = None;
@@ -485,15 +481,22 @@ where
                 (Role::Leader, Phase::Accept) => {
                     if !self.stopped() {
                         let ss = StopSign::with(self.config_id + 1, new_configuration, metadata);
-                        self.storage
-                            .set_stopsign(StopSignEntry::with(ss.clone(), false));
-                        self.leader_state.set_accepted_stopsign(self.pid);
+                        self.accept_stopsign(ss.clone());
                         self.send_accept_stopsign(ss);
                     } else {
                         return Err(ProposeErr::Reconfiguration(new_configuration));
                     }
                 }
-                (Role::Leader, Phase::FirstAccept) => todo!("Remove entry from first accept"),
+                (Role::Leader, Phase::FirstAccept) => {
+                    if !self.stopped() {
+                        self.send_first_accept();
+                        let ss = StopSign::with(self.config_id + 1, new_configuration, metadata);
+                        self.accept_stopsign(ss.clone());
+                        self.send_accept_stopsign(ss);
+                    } else {
+                        return Err(ProposeErr::Reconfiguration(new_configuration));
+                    }
+                }
                 _ => {
                     let ss = StopSign::with(self.config_id + 1, new_configuration, metadata);
                     self.forward_stopsign(ss);
@@ -508,6 +511,13 @@ where
         for pid in self.leader_state.get_promised_followers() {
             self.outgoing
                 .push(Message::with(self.pid, pid, acc_ss.clone()));
+        }
+    }
+
+    fn accept_stopsign(&mut self, ss: StopSign) {
+        self.storage.set_stopsign(StopSignEntry::with(ss, false));
+        if self.state.0 == Role::Leader {
+            self.leader_state.set_accepted_stopsign(self.pid);
         }
     }
 
@@ -557,7 +567,10 @@ where
         match self.state {
             (Role::Leader, Phase::Prepare) => self.pending_proposals.push(entry),
             (Role::Leader, Phase::Accept) => self.send_accept(entry),
-            (Role::Leader, Phase::FirstAccept) => self.send_first_accept(entry),
+            (Role::Leader, Phase::FirstAccept) => {
+                self.send_first_accept();
+                self.send_accept(entry);
+            }
             _ => self.forward_proposals(vec![entry]),
         }
     }
@@ -612,10 +625,6 @@ where
             #[cfg(feature = "batch_accept")]
             {
                 self.leader_state.set_batch_accept_meta(from, None);
-            }
-            #[cfg(feature = "latest_decide")]
-            {
-                self.leader_state.set_latest_decide_meta(from, None);
             }
             let ld = self.storage.get_decided_idx();
             let n_accepted = self.storage.get_accepted_round();
@@ -689,9 +698,8 @@ where
                 (Role::Leader, Phase::Prepare) => self.pending_proposals.append(&mut entries),
                 (Role::Leader, Phase::Accept) => self.send_batch_accept(entries),
                 (Role::Leader, Phase::FirstAccept) => {
-                    let rest = entries.split_off(1);
-                    self.send_first_accept(entries.pop().unwrap());
-                    self.send_batch_accept(rest);
+                    self.send_first_accept();
+                    self.send_batch_accept(entries);
                 }
                 _ => self.forward_proposals(entries),
             }
@@ -708,15 +716,16 @@ where
                 }
                 (Role::Leader, Phase::Accept) => self.send_accept_stopsign(ss),
                 (Role::Leader, Phase::FirstAccept) => {
-                    todo!()
+                    self.send_first_accept();
+                    self.send_accept_stopsign(ss);
                 }
                 _ => self.forward_stopsign(ss),
             }
         }
     }
 
-    fn send_first_accept(&mut self, entry: T) {
-        let f = FirstAccept::with(self.leader_state.n_leader, vec![entry.clone()]);
+    fn send_first_accept(&mut self) {
+        let f = FirstAccept::with(self.leader_state.n_leader);
         for pid in self.leader_state.get_promised_followers() {
             self.outgoing.push(Message::with(
                 self.pid,
@@ -724,12 +733,24 @@ where
                 PaxosMsg::FirstAccept(f.clone()),
             ));
         }
-        let la = self.storage.append_entry(entry);
-        self.leader_state.set_accepted_idx(self.pid, la);
         self.state.1 = Phase::Accept;
     }
 
+    fn send_accept_and_cache(&mut self, to: u64, entries: Vec<T>) {
+        let acc = AcceptDecide::with(
+            self.leader_state.n_leader,
+            self.leader_state.get_chosen_idx(),
+            entries,
+        );
+        let cache_idx = self.outgoing.len();
+        self.outgoing
+            .push(Message::with(self.pid, to, PaxosMsg::AcceptDecide(acc)));
+        self.leader_state.set_batch_accept_meta(to, Some(cache_idx));
+    }
+
     fn send_accept(&mut self, entry: T) {
+        let la = self.storage.append_entry(entry.clone());
+        self.leader_state.set_accepted_idx(self.pid, la);
         for pid in self.leader_state.get_promised_followers() {
             if cfg!(feature = "batch_accept") {
                 match self.leader_state.get_batch_accept_meta(pid) {
@@ -737,30 +758,10 @@ where
                         let Message { msg, .. } = self.outgoing.get_mut(outgoing_idx).unwrap();
                         match msg {
                             PaxosMsg::AcceptDecide(a) => a.entries.push(entry.clone()),
-                            PaxosMsg::FirstAccept(f) => f.entries.push(entry.clone()),
-                            _ => panic!("Not Accept or AcceptSync when batching"),
+                            _ => self.send_accept_and_cache(pid, vec![entry.clone()]),
                         }
                     }
-                    _ => {
-                        let acc = AcceptDecide::with(
-                            self.leader_state.n_leader,
-                            self.leader_state.get_chosen_idx(),
-                            vec![entry.clone()],
-                        );
-                        let cache_idx = self.outgoing.len();
-                        self.outgoing.push(Message::with(
-                            self.pid,
-                            pid,
-                            PaxosMsg::AcceptDecide(acc),
-                        ));
-                        self.leader_state
-                            .set_batch_accept_meta(pid, Some(cache_idx));
-                        #[cfg(feature = "latest_decide")]
-                        {
-                            self.leader_state
-                                .set_latest_decide_meta(pid, Some(cache_idx));
-                        }
-                    }
+                    _ => self.send_accept_and_cache(pid, vec![entry.clone()]),
                 }
             } else {
                 let acc = AcceptDecide::with(
@@ -772,11 +773,11 @@ where
                     .push(Message::with(self.pid, pid, PaxosMsg::AcceptDecide(acc)));
             }
         }
-        let la = self.storage.append_entry(entry);
-        self.leader_state.set_accepted_idx(self.pid, la);
     }
 
     fn send_batch_accept(&mut self, entries: Vec<T>) {
+        let la = self.storage.append_entries(entries.clone());
+        self.leader_state.set_accepted_idx(self.pid, la);
         for pid in self.leader_state.get_promised_followers() {
             if cfg!(feature = "batch_accept") {
                 match self.leader_state.get_batch_accept_meta(pid) {
@@ -784,30 +785,10 @@ where
                         let Message { msg, .. } = self.outgoing.get_mut(outgoing_idx).unwrap();
                         match msg {
                             PaxosMsg::AcceptDecide(a) => a.entries.append(entries.clone().as_mut()),
-                            PaxosMsg::FirstAccept(f) => f.entries.append(entries.clone().as_mut()),
-                            _ => panic!("Not Accept or AcceptSync when batching"),
+                            _ => self.send_accept_and_cache(pid, entries.clone()),
                         }
                     }
-                    _ => {
-                        let acc = AcceptDecide::with(
-                            self.leader_state.n_leader,
-                            self.leader_state.get_chosen_idx(),
-                            entries.clone(),
-                        );
-                        let cache_idx = self.outgoing.len();
-                        self.outgoing.push(Message::with(
-                            self.pid,
-                            pid,
-                            PaxosMsg::AcceptDecide(acc),
-                        ));
-                        self.leader_state
-                            .set_batch_accept_meta(pid, Some(cache_idx));
-                        #[cfg(feature = "latest_decide")]
-                        {
-                            self.leader_state
-                                .set_latest_decide_meta(pid, Some(cache_idx));
-                        }
-                    }
+                    _ => self.send_accept_and_cache(pid, entries.clone()),
                 }
             } else {
                 let acc = AcceptDecide::with(
@@ -819,8 +800,6 @@ where
                     .push(Message::with(self.pid, pid, PaxosMsg::AcceptDecide(acc)));
             }
         }
-        let la = self.storage.append_entries(entries);
-        self.leader_state.set_accepted_idx(self.pid, la);
     }
 
     fn create_pending_proposals_snapshot(&mut self) -> (u64, S) {
@@ -899,8 +878,7 @@ where
 
     fn adopt_pending_stopsign(&mut self) {
         if let Some(ss) = self.pending_stopsign.take() {
-            self.storage.set_stopsign(StopSignEntry::with(ss, false));
-            self.leader_state.set_accepted_stopsign(self.pid);
+            self.accept_stopsign(ss);
         }
     }
 
@@ -975,8 +953,7 @@ where
                     self.storage.append_on_prefix(ld, sfx);
                 }
                 if let Some(ss) = max_stopsign {
-                    self.storage.set_stopsign(StopSignEntry::with(ss, false));
-                    self.leader_state.set_accepted_stopsign(self.pid);
+                    self.accept_stopsign(ss);
                 } else {
                     self.append_pending_proposals();
                     self.adopt_pending_stopsign();
@@ -994,8 +971,7 @@ where
                     _ => unimplemented!(),
                 }
                 if let Some(ss) = max_stopsign {
-                    self.storage.set_stopsign(StopSignEntry::with(ss, false));
-                    self.leader_state.set_accepted_stopsign(self.pid);
+                    self.accept_stopsign(ss);
                 } else {
                     self.merge_pending_proposals_with_snapshot();
                     self.adopt_pending_stopsign();
@@ -1109,29 +1085,26 @@ where
                     self.leader_state.n_leader,
                     self.leader_state.get_chosen_idx(),
                 );
-                if cfg!(feature = "latest_decide") {
-                    let promised_followers = self.leader_state.get_promised_followers();
-                    for pid in promised_followers {
-                        match self.leader_state.get_latest_decide_meta(pid) {
-                            Some((n, outgoing_dec_idx)) if n == self.leader_state.n_leader => {
+                for pid in self.leader_state.get_promised_followers() {
+                    if cfg!(feature = "batch_accept") {
+                        match self.leader_state.get_batch_accept_meta(pid) {
+                            Some((n, outgoing_idx)) if n == self.leader_state.n_leader => {
                                 let Message { msg, .. } =
-                                    self.outgoing.get_mut(outgoing_dec_idx).unwrap();
+                                    self.outgoing.get_mut(outgoing_idx).unwrap();
                                 match msg {
                                     PaxosMsg::AcceptDecide(a) => {
                                         a.ld = self.leader_state.get_chosen_idx()
                                     }
-                                    PaxosMsg::Decide(d) => {
-                                        d.ld = self.leader_state.get_chosen_idx()
-                                    }
                                     _ => {
-                                        panic!("Cached Message<T> in outgoing was not Decide")
+                                        self.outgoing.push(Message::with(
+                                            self.pid,
+                                            pid,
+                                            PaxosMsg::Decide(d),
+                                        ));
                                     }
                                 }
                             }
                             _ => {
-                                let cache_dec_idx = self.outgoing.len();
-                                self.leader_state
-                                    .set_latest_decide_meta(pid, Some(cache_dec_idx));
                                 self.outgoing.push(Message::with(
                                     self.pid,
                                     pid,
@@ -1139,9 +1112,7 @@ where
                                 ));
                             }
                         }
-                    }
-                } else {
-                    for pid in self.leader_state.get_promised_followers() {
+                    } else {
                         self.outgoing
                             .push(Message::with(self.pid, pid, PaxosMsg::Decide(d)));
                     }
@@ -1291,10 +1262,10 @@ where
                             stopsign: _my_ss,
                         } = ss_entry;
                         if !has_decided {
-                            self.storage.set_stopsign(StopSignEntry::with(ss, false));
+                            self.accept_stopsign(ss);
                         }
                     } else {
-                        self.storage.set_stopsign(StopSignEntry::with(ss, false));
+                        self.accept_stopsign(ss);
                     }
                     let a = AcceptedStopSign::with(accsync.n);
                     self.outgoing.push(Message::with(
@@ -1315,12 +1286,10 @@ where
         }
     }
 
-    fn handle_firstaccept(&mut self, f: FirstAccept<T>) {
+    fn handle_firstaccept(&mut self, f: FirstAccept) {
         debug!(self.logger, "Incoming message First Accept");
         if self.storage.get_promise() == f.n && self.state == (Role::Follower, Phase::FirstAccept) {
-            let entries = f.entries;
             self.storage.set_accepted_round(f.n);
-            self.accept_entries(f.n, entries);
             self.state.1 = Phase::Accept;
             self.forward_pending_proposals();
         }
@@ -1339,8 +1308,7 @@ where
 
     fn handle_accept_stopsign(&mut self, acc_ss: AcceptStopSign) {
         if self.storage.get_promise() == acc_ss.n && self.state == (Role::Follower, Phase::Accept) {
-            self.storage
-                .set_stopsign(StopSignEntry::with(acc_ss.ss, false));
+            self.accept_stopsign(acc_ss.ss);
             let a = AcceptedStopSign::with(acc_ss.n);
             self.outgoing.push(Message::with(
                 self.pid,
@@ -1363,7 +1331,7 @@ where
                 .get_stopsign()
                 .expect("No stopsign found when deciding!");
             ss.decided = true;
-            self.storage.set_stopsign(ss);
+            self.storage.set_stopsign(ss); // need to set it again now with the modified decided flag
             self.storage.set_decided_idx(self.storage.get_log_len() + 1);
         }
     }

--- a/omnipaxos_core/src/util.rs
+++ b/omnipaxos_core/src/util.rs
@@ -58,7 +58,6 @@ where
     pub max_promise_meta: PromiseMetaData,
     pub max_promise: SyncItem<T, S>,
     pub batch_accept_meta: Vec<Option<(Ballot, usize)>>, //  index in outgoing
-    pub latest_decide_meta: Vec<Option<(Ballot, usize)>>,
     pub accepted_stopsign: Vec<bool>,
     pub max_pid: usize,
     pub majority: usize,
@@ -84,7 +83,6 @@ where
             max_promise_meta: PromiseMetaData::default(),
             max_promise: SyncItem::None,
             batch_accept_meta: vec![None; max_pid],
-            latest_decide_meta: vec![None; max_pid],
             accepted_stopsign: vec![false; max_pid],
             max_pid,
             majority,
@@ -140,10 +138,6 @@ where
         self.batch_accept_meta = vec![None; self.max_pid];
     }
 
-    pub fn reset_latest_decided_meta(&mut self) {
-        self.latest_decide_meta = vec![None; self.max_pid];
-    }
-
     pub fn set_chosen_idx(&mut self, idx: u64) {
         self.lc = idx;
     }
@@ -166,24 +160,12 @@ where
         self.batch_accept_meta[Self::pid_to_idx(pid)] = meta;
     }
 
-    pub fn set_latest_decide_meta(&mut self, pid: u64, idx: Option<usize>) {
-        let meta = idx.map(|x| (self.n_leader, x));
-        self.latest_decide_meta[Self::pid_to_idx(pid)] = meta;
-    }
-
     pub fn set_accepted_idx(&mut self, pid: u64, idx: u64) {
         self.las[Self::pid_to_idx(pid)] = idx;
     }
 
     pub fn get_batch_accept_meta(&self, pid: u64) -> Option<(Ballot, usize)> {
         self.batch_accept_meta
-            .get(Self::pid_to_idx(pid))
-            .unwrap()
-            .as_ref()
-            .copied()
-    }
-    pub fn get_latest_decide_meta(&self, pid: u64) -> Option<(Ballot, usize)> {
-        self.latest_decide_meta
             .get(Self::pid_to_idx(pid))
             .unwrap()
             .as_ref()

--- a/omnipaxos_core/tests/consensus_test.rs
+++ b/omnipaxos_core/tests/consensus_test.rs
@@ -25,7 +25,7 @@ fn consensus_test() {
 
     let mut vec_proposals = vec![];
     let mut futures = vec![];
-    for i in 0..cfg.num_proposals {
+    for i in 1..=cfg.num_proposals {
         let (kprom, kfuture) = promise::<Value>();
         vec_proposals.push(Value(i));
         px.on_definition(|x| {

--- a/omnipaxos_core/tests/consensus_test.rs
+++ b/omnipaxos_core/tests/consensus_test.rs
@@ -29,7 +29,7 @@ fn consensus_test() {
         let (kprom, kfuture) = promise::<Value>();
         vec_proposals.push(Value(i));
         px.on_definition(|x| {
-            x.propose(Value(i));
+            x.paxos.append(Value(i)).expect("Failed to append");
             x.add_ask(Ask::new(kprom, ()))
         });
         futures.push(kfuture);

--- a/omnipaxos_core/tests/proposal_test.rs
+++ b/omnipaxos_core/tests/proposal_test.rs
@@ -44,7 +44,7 @@ fn forward_proposal_test() {
     let (kprom_px, kfuture_px) = promise::<Value>();
     px.on_definition(|x| {
         x.add_ask(Ask::new(kprom_px, ()));
-        x.propose(Value(123));
+        x.paxos.append(Value(123)).expect("Failed to append");
     });
 
     kfuture_px

--- a/omnipaxos_core/tests/reconfig_test.rs
+++ b/omnipaxos_core/tests/reconfig_test.rs
@@ -1,0 +1,82 @@
+pub mod test_config;
+pub mod util;
+
+use crate::util::{Value, SS_METADATA};
+use kompact::prelude::{promise, Ask, FutureCollection};
+use omnipaxos_core::sequence_paxos::ReconfigurationRequest;
+use serial_test::serial;
+use test_config::TestConfig;
+use util::TestSystem;
+
+/// Verifies that the decided StopSign is correct and error is returned when trying to append after decided StopSign.
+#[test]
+#[serial]
+fn reconfig_test() {
+    let cfg = TestConfig::load("consensus_test").expect("Test config loaded");
+
+    let sys = TestSystem::with(cfg.num_nodes, cfg.ble_hb_delay, cfg.num_threads);
+
+    let (_, px) = sys.ble_paxos_nodes().get(&1).unwrap();
+
+    let mut vec_proposals = vec![];
+    let mut futures = vec![];
+    for i in 1..=cfg.num_proposals {
+        let (kprom, kfuture) = promise::<Value>();
+        vec_proposals.push(Value(i));
+        px.on_definition(|x| {
+            x.paxos.append(Value(i)).expect("Failed to append");
+            x.add_ask(Ask::new(kprom, ()))
+        });
+        futures.push(kfuture);
+    }
+
+    sys.start_all_nodes();
+
+    match FutureCollection::collect_with_timeout::<Vec<_>>(futures, cfg.wait_timeout) {
+        Ok(_) => {}
+        Err(e) => panic!("Error on collecting futures of decided proposals: {}", e),
+    }
+
+    let new_config: Vec<u64> = (cfg.num_nodes as u64..(cfg.num_nodes as u64 + 3)).collect();
+    let rc = ReconfigurationRequest::with(new_config.clone(), Some(vec![SS_METADATA]));
+
+    let reconfig_f = px.on_definition(|x| {
+        let (kprom, kfuture) = promise::<Value>();
+        x.paxos.reconfigure(rc).expect("Failed to reconfigure");
+        x.add_ask(Ask::new(kprom, ()));
+        kfuture
+    });
+
+    let decided_ss_metadata = reconfig_f
+        .wait_timeout(cfg.wait_timeout)
+        .expect("Failed to collect reconfiguration future");
+    assert_eq!(decided_ss_metadata, Value(SS_METADATA as u64));
+
+    let decided_nodes = sys
+        .ble_paxos_nodes()
+        .iter()
+        .fold(vec![], |mut x, (pid, comps)| {
+            let paxos = &comps.1;
+            let ss = paxos.on_definition(|x| x.paxos.is_reconfigured());
+            if let Some(stop_sign) = ss {
+                assert_eq!(stop_sign.nodes, new_config);
+                x.push(pid);
+            }
+            x
+        });
+    let quorum_size = cfg.num_nodes as usize / 2 + 1;
+    assert!(decided_nodes.len() >= quorum_size);
+
+    let pid = *decided_nodes.last().unwrap();
+    let (_ble, paxos) = sys.ble_paxos_nodes().get(pid).unwrap();
+    paxos.on_definition(|x| {
+        x.paxos
+            .append(Value(0))
+            .expect_err("Should not be able to propose after decided StopSign!")
+    });
+
+    match sys.kompact_system.shutdown() {
+        Ok(_) => {}
+        Err(e) => panic!("Error on kompact shutdown: {}", e),
+    };
+}

--- a/omnipaxos_core/tests/trim_test.rs
+++ b/omnipaxos_core/tests/trim_test.rs
@@ -24,7 +24,7 @@ fn trim_test() {
 
     let mut vec_proposals = vec![];
     let mut futures = vec![];
-    for i in 0..cfg.num_proposals {
+    for i in 1..=cfg.num_proposals {
         let (kprom, kfuture) = promise::<Value>();
         vec_proposals.push(Value(i));
         px.on_definition(|x| {
@@ -79,7 +79,7 @@ fn double_trim_test() {
 
     let mut vec_proposals = vec![];
     let mut futures = vec![];
-    for i in 0..cfg.num_proposals {
+    for i in 1..=cfg.num_proposals {
         let (kprom, kfuture) = promise::<Value>();
 
         vec_proposals.push(Value(i));

--- a/omnipaxos_core/tests/trim_test.rs
+++ b/omnipaxos_core/tests/trim_test.rs
@@ -15,7 +15,7 @@ const GC_INDEX_INCREMENT: u64 = 10;
 /// if the first [`gc_index`] are removed.
 #[test]
 #[serial]
-fn gc_test() {
+fn trim_test() {
     let cfg = TestConfig::load("gc_test").expect("Test config loaded");
 
     let sys = TestSystem::with(cfg.num_nodes, cfg.ble_hb_delay, cfg.num_threads);
@@ -28,7 +28,7 @@ fn gc_test() {
         let (kprom, kfuture) = promise::<Value>();
         vec_proposals.push(Value(i));
         px.on_definition(|x| {
-            x.propose(Value(i));
+            x.paxos.append(Value(i)).expect("Failed to append");
             x.add_ask(Ask::new(kprom, ()))
         });
         futures.push(kfuture);
@@ -42,7 +42,7 @@ fn gc_test() {
     }
 
     px.on_definition(|x| {
-        x.trim(Some(cfg.gc_idx));
+        x.paxos.trim(Some(cfg.gc_idx)).expect("Failed to trim");
     });
 
     thread::sleep(cfg.wait_timeout);
@@ -55,7 +55,7 @@ fn gc_test() {
         }));
     }
 
-    check_gc(vec_proposals, seq_after, cfg.gc_idx);
+    check_trim(vec_proposals, seq_after, cfg.gc_idx);
 
     println!("Pass gc");
 
@@ -70,7 +70,7 @@ fn gc_test() {
 /// if the first [`gc_index`] + an increment are removed.
 #[test]
 #[serial]
-fn double_gc_test() {
+fn double_trim_test() {
     let cfg = TestConfig::load("gc_test").expect("Test config loaded");
 
     let sys = TestSystem::with(cfg.num_nodes, cfg.ble_hb_delay, cfg.num_threads);
@@ -84,7 +84,7 @@ fn double_gc_test() {
 
         vec_proposals.push(Value(i));
         px.on_definition(|x| {
-            x.propose(Value(i));
+            x.paxos.append(Value(i)).expect("Failed to append");
             x.add_ask(Ask::new(kprom, ()))
         });
         futures.push(kfuture);
@@ -98,13 +98,15 @@ fn double_gc_test() {
     }
 
     px.on_definition(|x| {
-        x.trim(Some(cfg.gc_idx));
+        x.paxos.trim(Some(cfg.gc_idx)).expect("Failed to trim");
     });
 
     thread::sleep(cfg.wait_timeout);
 
     px.on_definition(|x| {
-        x.trim(Some(cfg.gc_idx + GC_INDEX_INCREMENT));
+        x.paxos
+            .trim(Some(cfg.gc_idx + GC_INDEX_INCREMENT))
+            .expect("Failed to trim");
     });
 
     thread::sleep(cfg.wait_timeout);
@@ -117,7 +119,7 @@ fn double_gc_test() {
         }));
     }
 
-    check_gc(
+    check_trim(
         vec_proposals,
         seq_after_double,
         cfg.gc_idx + GC_INDEX_INCREMENT,
@@ -131,7 +133,7 @@ fn double_gc_test() {
     };
 }
 
-fn check_gc(vec_proposals: Vec<Value>, seq_after: Vec<(&u64, Vec<Value>)>, gc_idx: u64) {
+fn check_trim(vec_proposals: Vec<Value>, seq_after: Vec<(&u64, Vec<Value>)>, gc_idx: u64) {
     for i in 0..seq_after.len() {
         let (_, after) = seq_after.get(i).expect("After log");
 

--- a/omnipaxos_runtime/Cargo.toml
+++ b/omnipaxos_runtime/Cargo.toml
@@ -14,10 +14,9 @@ serial_test = "0.5.1"
 [features]
 batch_accept = []
 latest_accepted = []
-latest_decide = []
 continued_leader_reconfiguration = []
 
-default = ["latest_accepted", "latest_decide", "continued_leader_reconfiguration", "batch_accept"]
+default = ["latest_accepted", "continued_leader_reconfiguration", "batch_accept"]
 
 #[profile.release]
 #lto = true


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Issues
Fix #39 

## Breaking Changes
- The `stopped()` function has been made private and instead has a corresponding public function `is_reconfigured()` that only returns the StopSign if it is **decided** (related to #45)
- Removed the `latest_decided` feature flag and merged its functionality with `batch_accept`

## Other Changes
- Reconfiguration can now be forwarded from followers to the leader.
- FirstAccept does not contain any data and thus allows for Reconfiguration to be the first entry too.
