### PR TITLE
Atomic storage & In-memory cache for state

### DIFF
--- a/omnipaxos_core/src/storage.rs
+++ b/omnipaxos_core/src/storage.rs
@@ -81,7 +81,6 @@ where
 /// CachedState is an in-memory state storage for SequencePaxos, the stuct
 /// caches any new state that is written to persistent storage and
 /// can be used recover state when an atomic commit fails.
-// todo Implement caching, atomic commit and recovery in SequencePaxos
 #[derive(Clone)]
 pub(crate) struct CachedState {
     /// Last cached promised round.
@@ -95,23 +94,20 @@ pub(crate) struct CachedState {
 }
 
 impl CachedState {
-    pub fn set_promise(&mut self, n_prom: Ballot) -> Result<(), StorageErr> {
+    pub fn set_promise(&mut self, n_prom: Ballot) {
         self.n_prom = n_prom;
-        Ok(())
     }
 
-    pub fn set_decided_idx(&mut self, ld: u64) -> Result<(), StorageErr> {
+    pub fn set_decided_idx(&mut self, ld: u64) {
         self.ld = ld;
-        Ok(())
     }
 
     pub fn get_decided_idx(&self) -> u64 {
         self.ld
     }
 
-    pub fn set_accepted_round(&mut self, na: Ballot) -> Result<(), StorageErr> {
+    pub fn set_accepted_round(&mut self, na: Ballot) {
         self.acc_round = na;
-        Ok(())
     }
 
     pub fn get_accepted_round(&self) -> Ballot {
@@ -122,9 +118,8 @@ impl CachedState {
         self.n_prom
     }
 
-    pub fn set_compacted_idx(&mut self, trimmed_idx: u64) -> Result<(), StorageErr> {
+    pub fn set_compacted_idx(&mut self, trimmed_idx: u64) {
         self.trimmed_idx = trimmed_idx;
-        Ok(())
     }
 
     pub fn get_compacted_idx(&self) -> u64 {
@@ -165,32 +160,32 @@ where
     fn set_decided_idx(&mut self, ld: u64) -> Result<(), StorageErr>;
 
     /// Returns the decided index in the log.
-    fn get_decided_idx(&self) -> u64;
+    fn get_decided_idx(&self) -> Result<u64, StorageErr>;
 
     /// Sets the latest accepted round.
     fn set_accepted_round(&mut self, na: Ballot) -> Result<(), StorageErr>;
 
     /// Returns the latest round in which entries have been accepted.
-    fn get_accepted_round(&self) -> Ballot;
+    fn get_accepted_round(&self) -> Result<Ballot, StorageErr>;
 
     /// Returns the entries in the log in the index interval of [from, to).
     /// If entries **do not exist for the complete interval**, an empty Vector should be returned.
-    fn get_entries(&self, from: u64, to: u64) -> Vec<T>;
+    fn get_entries(&self, from: u64, to: u64) -> Result<Vec<T>, StorageErr>;
 
     /// Returns the current length of the log.
-    fn get_log_len(&self) -> u64;
+    fn get_log_len(&self) -> Result<u64, StorageErr>;
 
     /// Returns the suffix of entries in the log from index `from`.
-    fn get_suffix(&self, from: u64) -> Vec<T>;
+    fn get_suffix(&self, from: u64) -> Result<Vec<T>, StorageErr>;
 
     /// Returns the round that has been promised.
-    fn get_promise(&self) -> Ballot;
+    fn get_promise(&self) -> Result<Ballot, StorageErr>;
 
     /// Sets the StopSign used for reconfiguration.
     fn set_stopsign(&mut self, s: StopSignEntry) -> Result<(), StorageErr>;
 
     /// Returns the stored StopSign.
-    fn get_stopsign(&self) -> Option<StopSignEntry>;
+    fn get_stopsign(&self) ->  Result<Option<StopSignEntry>, StorageErr>;
 
     /// Removes elements up to the given [`idx`] from storage.
     fn trim(&mut self, idx: u64) -> Result<(), StorageErr>;
@@ -199,13 +194,13 @@ where
     fn set_compacted_idx(&mut self, idx: u64) -> Result<(), StorageErr>;
 
     /// Returns the garbage collector index from storage.
-    fn get_compacted_idx(&self) -> u64;
+    fn get_compacted_idx(&self) -> Result<u64, StorageErr>;
 
     /// Sets the snapshot.
     fn set_snapshot(&mut self, snapshot: S) -> Result<(), StorageErr>;
 
     /// Returns the stored snapshot.
-    fn get_snapshot(&self) -> Option<S>;
+    fn get_snapshot(&self) -> Result<Option<S>, StorageErr>;
 }
 
 #[derive(Clone, Debug)]

--- a/omnipaxos_core/src/storage.rs
+++ b/omnipaxos_core/src/storage.rs
@@ -185,7 +185,7 @@ where
     fn set_stopsign(&mut self, s: StopSignEntry) -> Result<(), StorageErr>;
 
     /// Returns the stored StopSign.
-    fn get_stopsign(&self) ->  Result<Option<StopSignEntry>, StorageErr>;
+    fn get_stopsign(&self) -> Result<Option<StopSignEntry>, StorageErr>;
 
     /// Removes elements up to the given [`idx`] from storage.
     fn trim(&mut self, idx: u64) -> Result<(), StorageErr>;

--- a/omnipaxos_core/tests/consensus_test.rs
+++ b/omnipaxos_core/tests/consensus_test.rs
@@ -80,7 +80,8 @@ fn read_test() {
 
     let exp_snapshot = LatestValue::create(snapshotted);
 
-    let mut storage = StorageType::<Value, LatestValue>::with(cfg.storage_type, READ_PATH);
+    let temp_dir = create_temp_dir();
+    let mut storage = StorageType::<Value, LatestValue>::with(cfg.storage_type, &temp_dir);
     storage
         .append_entries(log.clone())
         .expect("Failed to append log entries");
@@ -162,7 +163,8 @@ fn read_entries_test() {
 
     let exp_snapshot = LatestValue::create(snapshotted);
 
-    let mut storage = StorageType::<Value, LatestValue>::with(cfg.storage_type, READ_ENTRIES_PATH);
+    let temp_dir = create_temp_dir();
+    let mut storage = StorageType::<Value, LatestValue>::with(cfg.storage_type, &temp_dir);
     storage
         .append_entries(log.clone())
         .expect("Failed to append log entries");

--- a/omnipaxos_core/tests/utils.rs
+++ b/omnipaxos_core/tests/utils.rs
@@ -8,7 +8,7 @@ use omnipaxos_core::{
     ballot_leader_election::{messages::BLEMessage, BLEConfig, Ballot, BallotLeaderElection},
     messages::Message,
     sequence_paxos::{SequencePaxos, SequencePaxosConfig},
-    storage::{Entry, Snapshot, StopSign, Storage, StorageErr},
+    storage::{Entry, Snapshot, StopSign, StopSignEntry, Storage, StorageErr},
 };
 use omnipaxos_storage::{
     memory_storage::MemoryStorage,
@@ -161,7 +161,7 @@ where
         }
     }
 
-    fn get_decided_idx(&self) -> u64 {
+    fn get_decided_idx(&self) -> Result<u64, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_decided_idx(),
             StorageType::Memory(mem_s) => mem_s.get_decided_idx(),
@@ -175,35 +175,37 @@ where
         }
     }
 
-    fn get_accepted_round(&self) -> Ballot {
+    fn get_accepted_round(
+        &self,
+    ) -> Result<omnipaxos_core::ballot_leader_election::Ballot, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_accepted_round(),
             StorageType::Memory(mem_s) => mem_s.get_accepted_round(),
         }
     }
 
-    fn get_entries(&self, from: u64, to: u64) -> Vec<T> {
+    fn get_entries(&self, from: u64, to: u64) -> Result<Vec<T>, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_entries(from, to),
             StorageType::Memory(mem_s) => mem_s.get_entries(from, to),
         }
     }
 
-    fn get_log_len(&self) -> u64 {
+    fn get_log_len(&self) -> Result<u64, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_log_len(),
             StorageType::Memory(mem_s) => mem_s.get_log_len(),
         }
     }
 
-    fn get_suffix(&self, from: u64) -> Vec<T> {
+    fn get_suffix(&self, from: u64) -> Result<Vec<T>, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_suffix(from),
             StorageType::Memory(mem_s) => mem_s.get_suffix(from),
         }
     }
 
-    fn get_promise(&self) -> Ballot {
+    fn get_promise(&self) -> Result<omnipaxos_core::ballot_leader_election::Ballot, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_promise(),
             StorageType::Memory(mem_s) => mem_s.get_promise(),
@@ -220,7 +222,7 @@ where
         }
     }
 
-    fn get_stopsign(&self) -> Option<omnipaxos_core::storage::StopSignEntry> {
+    fn get_stopsign(&self) -> Result<std::option::Option<StopSignEntry>, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_stopsign(),
             StorageType::Memory(mem_s) => mem_s.get_stopsign(),
@@ -241,7 +243,7 @@ where
         }
     }
 
-    fn get_compacted_idx(&self) -> u64 {
+    fn get_compacted_idx(&self) -> Result<u64, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_compacted_idx(),
             StorageType::Memory(mem_s) => mem_s.get_compacted_idx(),
@@ -255,7 +257,7 @@ where
         }
     }
 
-    fn get_snapshot(&self) -> Option<S> {
+    fn get_snapshot(&self) -> Result<std::option::Option<S>, StorageErr> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_snapshot(),
             StorageType::Memory(mem_s) => mem_s.get_snapshot(),
@@ -500,12 +502,6 @@ impl TestSystem {
         } else {
             conf.executor(|t| crossbeam_workstealing_pool::dyn_pool(t))
         };
-    }
-}
-
-impl Drop for TestSystem {
-    fn drop(&mut self) {
-        clear_storage();
     }
 }
 

--- a/omnipaxos_storage/src/memory_storage.rs
+++ b/omnipaxos_storage/src/memory_storage.rs
@@ -32,13 +32,13 @@ where
 {
     fn append_entry(&mut self, entry: T) -> Result<u64, StorageErr> {
         self.log.push(entry);
-        Ok(self.get_log_len())
+        self.get_log_len()
     }
 
     fn append_entries(&mut self, entries: Vec<T>) -> Result<u64, StorageErr> {
         let mut e = entries;
         self.log.append(&mut e);
-        Ok(self.get_log_len())
+        self.get_log_len()
     }
 
     fn append_on_prefix(&mut self, from_idx: u64, entries: Vec<T>) -> Result<u64, StorageErr> {
@@ -56,8 +56,8 @@ where
         Ok(())
     }
 
-    fn get_decided_idx(&self) -> u64 {
-        self.ld
+    fn get_decided_idx(&self) -> Result<u64, StorageErr> {
+        Ok(self.ld)
     }
 
     fn set_accepted_round(&mut self, na: Ballot) -> Result<(), StorageErr> {
@@ -65,30 +65,31 @@ where
         Ok(())
     }
 
-    fn get_accepted_round(&self) -> Ballot {
-        self.acc_round
+    fn get_accepted_round(&self) -> Result<Ballot, StorageErr> {
+        Ok(self.acc_round)
     }
 
-    fn get_entries(&self, from: u64, to: u64) -> Vec<T> {
-        self.log
+    fn get_entries(&self, from: u64, to: u64) -> Result<Vec<T>, StorageErr> {
+        Ok(self
+            .log
             .get(from as usize..to as usize)
             .unwrap_or(&[])
-            .to_vec()
+            .to_vec())
     }
 
-    fn get_log_len(&self) -> u64 {
-        self.log.len() as u64
+    fn get_log_len(&self) -> Result<u64, StorageErr> {
+        Ok(self.log.len() as u64)
     }
 
-    fn get_suffix(&self, from: u64) -> Vec<T> {
+    fn get_suffix(&self, from: u64) -> Result<Vec<T>, StorageErr> {
         match self.log.get(from as usize..) {
-            Some(s) => s.to_vec(),
-            None => vec![],
+            Some(s) => Ok(s.to_vec()),
+            None => Ok(vec![]),
         }
     }
 
-    fn get_promise(&self) -> Ballot {
-        self.n_prom
+    fn get_promise(&self) -> Result<Ballot, StorageErr> {
+        Ok(self.n_prom)
     }
 
     fn set_stopsign(&mut self, s: StopSignEntry) -> Result<(), StorageErr> {
@@ -96,8 +97,8 @@ where
         Ok(())
     }
 
-    fn get_stopsign(&self) -> Option<StopSignEntry> {
-        self.stopsign.clone()
+    fn get_stopsign(&self) -> Result<std::option::Option<StopSignEntry>, StorageErr> {
+        Ok(self.stopsign.clone())
     }
 
     fn trim(&mut self, trimmed_idx: u64) -> Result<(), StorageErr> {
@@ -110,8 +111,8 @@ where
         Ok(())
     }
 
-    fn get_compacted_idx(&self) -> u64 {
-        self.trimmed_idx
+    fn get_compacted_idx(&self) -> Result<u64, StorageErr> {
+        Ok(self.trimmed_idx)
     }
 
     fn set_snapshot(&mut self, snapshot: S) -> Result<(), StorageErr> {
@@ -119,8 +120,8 @@ where
         Ok(())
     }
 
-    fn get_snapshot(&self) -> Option<S> {
-        self.snapshot.clone()
+    fn get_snapshot(&self) -> Result<std::option::Option<S>, StorageErr> {
+        Ok(self.snapshot.clone())
     }
 }
 


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [X] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)
- [X] You reference which issue is being closed in the PR text (if applicable)
- [ ] You updated the OmniPaxos book (if applicable)

## Issues

Fix #40

## Breaking Changes

* SequencePaxos reads from in-memory cache struct for state
* Operations that write to storage are Atomic  

## Other Changes

* Added `CachedState` for internal in-memory state storage
* Struct implementing `Storage` trait now returns `Result` for all operations
