### PR TITLE
Fix AccSync and Promise with Snapshots

### DIFF
--- a/omnipaxos_core/src/sequence_paxos/follower.rs
+++ b/omnipaxos_core/src/sequence_paxos/follower.rs
@@ -33,8 +33,18 @@ where
                     (None, suffix)
                 }
             } else if na == prep.n_accepted && accepted_idx > prep.accepted_idx {
-                let suffix = self.internal_storage.get_suffix(prep.accepted_idx);
-                (None, suffix)
+                if self.internal_storage.get_compacted_idx() > prep.accepted_idx
+                    && Self::use_snapshots()
+                {
+                    let delta_snapshot = self
+                        .internal_storage
+                        .create_diff_snapshot(prep.decided_idx, decided_idx);
+                    let suffix = self.internal_storage.get_suffix(decided_idx);
+                    (Some(delta_snapshot), suffix)
+                } else {
+                    let suffix = self.internal_storage.get_suffix(prep.accepted_idx);
+                    (None, suffix)
+                }
             } else {
                 (None, vec![])
             };

--- a/omnipaxos_storage/src/memory_storage.rs
+++ b/omnipaxos_storage/src/memory_storage.rs
@@ -97,7 +97,8 @@ where
     }
 
     fn trim(&mut self, trimmed_idx: u64) {
-        self.log.drain(0..trimmed_idx as usize);
+        self.log
+            .drain(0..(trimmed_idx as usize).min(self.log.len()));
     }
 
     fn set_compacted_idx(&mut self, trimmed_idx: u64) {

--- a/omnipaxos_storage/src/persistent_storage.rs
+++ b/omnipaxos_storage/src/persistent_storage.rs
@@ -281,7 +281,7 @@ where
     }
 
     fn append_on_prefix(&mut self, from_idx: u64, entries: Vec<T>) -> u64 {
-        if from_idx > 0 {
+        if from_idx > 0 && from_idx < self.get_log_len() {
             self.commitlog
                 .truncate(from_idx)
                 .expect("Failed to truncate log");
@@ -291,7 +291,7 @@ where
 
     fn get_entries(&self, from: u64, to: u64) -> Vec<T> {
         // Check if the commit log has entries up to the requested endpoint.
-        if to > self.commitlog.next_offset() {
+        if to > self.commitlog.next_offset() || from >= to {
             return vec![]; // Do an early return
         }
 


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran `rustfmt` on the code base before submitting (on latest nightly with rustfmt support)

## Issues
The issue that is addressed by this PR is an unaccounted for edge case in log synchronization when using snapshots.

Assume we are going to send an AccSync message.
The leader has a `decided_idx = 4` and a `compacted_idx = 4`, so his entire decided log is snapshotted and he does not have access to the individual entries anymore.
The follower has `decided_idx = 2`  and a `compacted_idx = 0`.

Currently the leader in this situation will try to create a delta snapshot from index 2 to 4 and a normal suffix for his further accepted entries.
The library will panic when trying to get the already compacted entries.
But even if we fix the panic, it is still not possible to create a correct delta snapshot, since we cannot access the required pieces of the log individually. Instead we should send a complete snapshot instead of the delta snapshot.

Analog problems also can occur when trying to construct a `Promise` message.

## Changes
To address this problem, this PR adds a few bounds checks or similar where necessary to prevent the mentioned panics.
Additionally, it adds the required logic to the leader and follower, to construct the correct `AccSync` and `Promise` messages when encountering the described edge case.

### Correctness
The described issue was discovered and the changes were tested using a DIY linearizability checker and the [ditm](https://github.com/JonathanArns/ditm) testing tool to simulate network partitions in a test cluster of 3 nodes.