### PR TITLE
fixed: doc sync stigger only set to haraldng/omnipaxos

### DIFF
--- a/.github/workflows/push_doc_changes_to_website.yml
+++ b/.github/workflows/push_doc_changes_to_website.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+    paths-ignore:
+      - '**'
+    if: github.repository == 'haraldng/omnipaxos'
+
   pull_request:
     branches:
       - master


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [y] You ran the local CI checker with `./check.sh` with no errors
- [y] You reference which issue is being closed in the PR text (if applicable)
- [y] You updated the OmniPaxos book (if applicable)

## Issues

Fixed the problems with `doc sync` feature. Now the doc synchronization action will only be trigger by operations on `harald/omnipaxso`.

## Breaking Changes
- .github/workflows/push_doc_changes_to_website.yml