### PR TITLE
Make Snapshot an associated type in Entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "omnipaxos_core",
     "omnipaxos_storage",
+    "omnipaxos_macros",
     "examples/kv_store"
 ]
 

--- a/docs/omnipaxos/communication.md
+++ b/docs/omnipaxos/communication.md
@@ -8,7 +8,7 @@ When a message is received from the network layer intended for our node, we need
 use omnipaxos_core::messages::Message;
 
 // handle incoming message from network layer
-let msg: Message<KeyValue, KVSnapshot> = ...;    // message to this node e.g. `msg.get_receiver() == 2`
+let msg: Message<KeyValue> = ...;    // message to this node e.g. `msg.get_receiver() == 2`
 omni_paxos.handle_incoming(msg);
 ```
 

--- a/docs/omnipaxos/compaction.md
+++ b/docs/omnipaxos/compaction.md
@@ -63,12 +63,23 @@ impl Snapshot<KeyValue> for KVSnapshot {
 
 The ``create()`` function tells `OmniPaxos` how to create a snapshot given a slice of entries of our `KeyValue` type. In our case, we simply want to insert the kv-pair into the hashmap. The `merge()` function defines how we can merge two snapshots. In our case, we will just insert/update the kv-pairs from the other snapshot. The `use_snapshots()` function tells `OmniPaxos` if snapshots should be used in the protocol. 
 
-With ``KVSnapshot``, we would have instead created our `OmniPaxos` node as follows:
+With ``KVSnapshot``, we would have instead implemented our [`KeyValue`](../index.md) that we defined earlier like this:
 ```rust,edition2018,no_run,noplaypen
-// ...same as shown before in the `OmniPaxos` chapter.
-let storage = MemoryStorage::<KeyValue, KVSnapshot)>::default();    // use KVSnapshot as type argument instead of ()
-let mut omni_paxos = omni_paxos_config.build(storage);
+use omnipaxos::storage::Entry;
+
+#[derive(Clone, Debug)]
+pub struct KeyValue {
+    pub key: String,
+    pub value: u64,
+}
+
+impl Entry for KeyValue {
+    type Snapshot = KVSnapshot;
+}
 ```
+
+> **Note:** If you do not wish to use snapshots, then simply derive the blanket implementation for `Entry` using the macro we showed [here](../index.md)
+
 We can now create snapshots and read snapshots from `OmniPaxos`. Furthermore, snapshotting allows us to either just do the snapshot locally or request all nodes in the cluster to do it with the boolean parameter `local_only`.
 ```rust,edition2018,no_run,noplaypen
 // we will try snapshotting the first 100 entries of the log.
@@ -101,4 +112,3 @@ if let Some(e) = omni_paxos.read(20) {
 }
 ```
 
-> **Note:** If your `Entry` type is not snapshottable, simply use `()` as the type argument for `Snapshot`.

--- a/docs/omnipaxos/features.md
+++ b/docs/omnipaxos/features.md
@@ -5,5 +5,6 @@ OmniPaxos provide several features that can be used to enhance both usability an
 - `logging` - System-wide logging with the slog crate.
 - `toml_config` - Create an OmniPaxos instance from a TOML configuration file.
 - `serde` - Serialization and deserialization of messages and internal structs with serde. This makes it convenient to use with any desired network implementation without having to implement your own serializer and deserializer.
+- `macros` - Macros for convenience, e.g., deriving blanket implementations for OmniPaxos traits.
 
 Configure the features in your `Cargo.toml` file. By default, `batch_accept` and `continued_leader_reconfiguration` are enabled. 

--- a/docs/omnipaxos/features.md
+++ b/docs/omnipaxos/features.md
@@ -1,7 +1,7 @@
 OmniPaxos provide several features that can be used to enhance both usability and performance:
 
 - `batch_accept`: Batch multiple log entries into a single message to reduce overhead during replication.
-- `continued_leader_reconfiguration` - When [reconfiguring](../reconfiguraiton.md), let the current leader become the initial leader in the new configuration (if possible). This can help shorten down-time during reconfiguration.
+- `continued_leader_reconfiguration` - When [reconfiguring](../reconfiguration.md), let the current leader become the initial leader in the new configuration (if possible). This can help shorten down-time during reconfiguration.
 - `logging` - System-wide logging with the slog crate.
 - `toml_config` - Create an OmniPaxos instance from a TOML configuration file.
 - `serde` - Serialization and deserialization of messages and internal structs with serde. This makes it convenient to use with any desired network implementation without having to implement your own serializer and deserializer.

--- a/docs/omnipaxos/features.md
+++ b/docs/omnipaxos/features.md
@@ -1,0 +1,9 @@
+OmniPaxos provide several features that can be used to enhance both usability and performance:
+
+- `batch_accept`: Batch multiple log entries into a single message to reduce overhead during replication.
+- `continued_leader_reconfiguration` - When [reconfiguring](../reconfiguraiton.md), let the current leader become the initial leader in the new configuration (if possible). This can help shorten down-time during reconfiguration.
+- `logging` - System-wide logging with the slog crate.
+- `toml_config` - Create an OmniPaxos instance from a TOML configuration file.
+- `serde` - Serialization and deserialization of messages and internal structs with serde. This makes it convenient to use with any desired network implementation without having to implement your own serializer and deserializer.
+
+Configure the features in your `Cargo.toml` file. By default, `batch_accept` and `continued_leader_reconfiguration` are enabled. 

--- a/docs/omnipaxos/index.md
+++ b/docs/omnipaxos/index.md
@@ -1,17 +1,23 @@
 # OmniPaxos
-Each server in the cluster should have a local instance of the  `OmniPaxos` struct. `OmniPaxos` maintains a local state of the replicated log, handles incoming messages and produces outgoing messages that the user has to fetch and send using their network implementation. The users also accesses the replicated log via `OmniPaxos`.
+Each server in the cluster should have a local instance of the `OmniPaxos` struct. `OmniPaxos` maintains a local state of the replicated log, handles incoming messages and produces outgoing messages that the user has to fetch and send using their network implementation. The users also accesses the replicated log via `OmniPaxos`.
 
 ## Example: Key-Value store
 As a guide for this tutorial, we will use OmniPaxos to implement a replicated log for the purpose of building a consistent Key-Value store. 
 
 We begin by defining the type that we want our log entries to consist of:
 ```rust,edition2018,no_run,noplaypen
-#[derive(Clone, Debug)] // Clone and Debug are required traits.
+use omnipaxos_macros::Entry;
+
+#[derive(Clone, Debug, Entry)] // Clone and Debug are required traits.
 pub struct KeyValue {
     pub key: String,
     pub value: u64,
 }
 ``` 
+
+`Entry` is the trait for representing the entries stored in the replicated log of OmniPaxos. Here, we derive the implementation of it for our `KeyValue` using a macro imported from `omnipaxos_macros`. We will also show how to implement the trait manually when we discuss [`Snapshots`](compaction.md#snapshot).
+
+> **Note** To use the #[derive(Entry)] macro, please make sure to add the `omnipaxos_macros` dependency to your Cargo.toml.
 
 ## Creating a Node
 With the structs for log entry and storage defined, we can now go ahead and create our `OmniPaxos` replica instance.  Let's assume we want our KV-store to be replicated on three servers. On, say node 2, we would do the following: 
@@ -38,8 +44,8 @@ let omnipaxos_config = OmniPaxosConfig {
     ..Default::default()
 }
 
-let storage = MemoryStorage::<KeyValue, ()>::default();
-let mut omni_paxos = omni_paxos_config.build(storage);
+let storage = MemoryStorage::default();
+let mut omni_paxos: OmniPaxos<KeyValue, MemoryStorage<KeyValue>> = omni_paxos_config.build(storage);
 ```
 With the toml_config feature enabled, `OmniPaxosConfig` also features a constructor `OmniPaxosConfig::with_toml()` that loads the values using [TOML](https://toml.io). One could then instead have the parameters in a file `config/node1.toml`
 

--- a/docs/omnipaxos/index.md
+++ b/docs/omnipaxos/index.md
@@ -6,7 +6,7 @@ As a guide for this tutorial, we will use OmniPaxos to implement a replicated lo
 
 We begin by defining the type that we want our log entries to consist of:
 ```rust,edition2018,no_run,noplaypen
-use omnipaxos_macros::Entry;
+use omnipaxos_core::macros::Entry;
 
 #[derive(Clone, Debug, Entry)] // Clone and Debug are required traits.
 pub struct KeyValue {
@@ -15,9 +15,9 @@ pub struct KeyValue {
 }
 ``` 
 
-`Entry` is the trait for representing the entries stored in the replicated log of OmniPaxos. Here, we derive the implementation of it for our `KeyValue` using a macro imported from `omnipaxos_macros`. We will also show how to implement the trait manually when we discuss [`Snapshots`](compaction.md#snapshot).
+`Entry` is the trait for representing the entries stored in the replicated log of OmniPaxos. Here, we derive the implementation of it for our `KeyValue` using a macro. We will also show how to implement the trait manually when we discuss [`Snapshots`](compaction.md#snapshot).
 
-> **Note** To use the #[derive(Entry)] macro, please make sure to add the `omnipaxos_macros` dependency to your Cargo.toml.
+> **Note** To use the #[derive(Entry)] macro, please make sure to enable the `macros` feature.
 
 ## Creating a Node
 With the structs for log entry and storage defined, we can now go ahead and create our `OmniPaxos` replica instance.  Let's assume we want our KV-store to be replicated on three servers. On, say node 2, we would do the following: 

--- a/docs/omnipaxos/log.md
+++ b/docs/omnipaxos/log.md
@@ -25,7 +25,7 @@ The read functions return `Option<LogEntry>` and `Option<Vec<LogEntry>>` respect
 - `Decided(T)`: The entry is decided and guaranteed to not be reverted. It is thus safe to apply a decided entry to the application state. For instance, in our case, it is safe to update our key-value store when we read a `Decided(KeyValue)` entry.
 - `Undecided(T)`: The entry is NOT decided and might be removed from the log at a later time. However, it could be useful in applications that allow speculative execution for example.
 - `Trimmed(TrimmedIndex)`: We tried to read an index where the entry has already been trimmed. 
-- `Snapshotted(SnapshottedEntry<T, S>)`: The index we read has already been compacted into a snapshot. We can access the snapshot from the field `snapshot` in `SnapshottedEntry`. In our case our this will correspond to `KVSnapshot` that we defined [here](../compaction.md).
+- `Snapshotted(SnapshottedEntry<T>)`: The index we read has already been compacted into a snapshot. We can access the snapshot from the field `snapshot` in `SnapshottedEntry`. In our case our this will correspond to `KVSnapshot` that we defined [here](../compaction.md).
 - `StopSign(StopSign)`: This Sequence Paxos instance has been stopped for reconfiguration. This implies that this log will not be appended anymore and one should use the new Sequence Paxos instead for writing.
 
 It is also possible to only read decided entries or snapshot from a specific index using `read_decided_suffix(idx)`.

--- a/docs/omnipaxos/reconfiguration.md
+++ b/docs/omnipaxos/reconfiguration.md
@@ -13,7 +13,7 @@ Calling ``reconfigure()`` will propose a `StopSign` entry to be appended. If it 
 
 ```rust,edition2018,no_run,noplaypen
 let idx: u64 = ...  // some index we last read from
-    let decided_entries: Option<Vec<LogEntry<KeyValue, KVSnapshot>>> = seq_paxos.read_decided_suffix(idx);
+    let decided_entries: Option<Vec<LogEntry<KeyValue>>> = seq_paxos.read_decided_suffix(idx);
     if let Some(de) = decided_entries {
         for d in de {
             match d {

--- a/docs/omnipaxos/storage.md
+++ b/docs/omnipaxos/storage.md
@@ -15,10 +15,9 @@ omnipaxos_storage = { git = "https://github.com/haraldng/omnipaxos", default-fea
 ```rust,edition2018,no_run,noplaypen
     // from the module omnipaxos_storage::memory_storage
     #[derive(Clone)]
-    pub struct MemoryStorage<T, S>
+    pub struct MemoryStorage<T>
     where
         T: Entry,
-        S: Snapshot<T>,
     {
         /// Vector which contains all the replicated entries in-memory.
         log: Vec<T>,
@@ -31,10 +30,9 @@ omnipaxos_storage = { git = "https://github.com/haraldng/omnipaxos", default-fea
         ...
     }
 
-    impl<T, S> Storage<T, S> for MemoryStorage<T, S>
+    impl<T> Storage<T> for MemoryStorage<T>
     where
         T: Entry,
-        S: Snapshot<T>,
     {
         fn append_entry(&mut self, entry: T) -> u64 {
             self.log.push(entry);

--- a/docs/structure.yml
+++ b/docs/structure.yml
@@ -23,6 +23,8 @@ OmniPaxos:
     path: "omnipaxos/compaction.md"
   Reconfiguration:
     path: "omnipaxos/reconfiguration.md"
+  Features:
+    path: "omnipaxos/features.md"
   Logging:
     path: "omnipaxos/logging.md"
 

--- a/examples/kv_store/Cargo.toml
+++ b/examples/kv_store/Cargo.toml
@@ -6,11 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-omnipaxos_core = { path = "../../omnipaxos_core" }
+omnipaxos_core = { path = "../../omnipaxos_core", features = ["macros"] }
 omnipaxos_storage = { path = "../../omnipaxos_storage" }
-omnipaxos_macros = { path = "../../omnipaxos_macros", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 
 [features]
-derive_entry = ["omnipaxos_macros"]
+derive_entry = []

--- a/examples/kv_store/Cargo.toml
+++ b/examples/kv_store/Cargo.toml
@@ -8,5 +8,9 @@ edition = "2021"
 [dependencies]
 omnipaxos_core = { path = "../../omnipaxos_core" }
 omnipaxos_storage = { path = "../../omnipaxos_storage" }
+omnipaxos_macros = { path = "../../omnipaxos_macros", optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
+
+[features]
+derive_entry = ["omnipaxos_macros"]

--- a/examples/kv_store/src/kv.rs
+++ b/examples/kv_store/src/kv.rs
@@ -1,18 +1,31 @@
+#[cfg(not(feature = "derive_entry"))]
+use omnipaxos_core::storage::Entry;
 use omnipaxos_core::storage::Snapshot;
+#[cfg(feature = "derive_entry")]
+use omnipaxos_macros::Entry;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "derive_entry", derive(Entry))]
+// if we do not want to use snapshots, we can simply derive the Entry trait for KeyValue.
 pub struct KeyValue {
     pub key: String,
     pub value: u64,
 }
 
+#[cfg(not(feature = "derive_entry"))]
+impl Entry for KeyValue {
+    // we can also use snapshots by implementing the Entry trait and manually setting the Snapshot type.
+    type Snapshot = KVSnapshot;
+}
+
+#[cfg(not(feature = "derive_entry"))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KVSnapshot {
     snapshotted: HashMap<String, u64>,
 }
-
+#[cfg(not(feature = "derive_entry"))]
 impl Snapshot<KeyValue> for KVSnapshot {
     fn create(entries: &[KeyValue]) -> Self {
         let mut snapshotted = HashMap::new();

--- a/examples/kv_store/src/kv.rs
+++ b/examples/kv_store/src/kv.rs
@@ -1,9 +1,11 @@
+#[cfg(feature = "derive_entry")]
+use omnipaxos_core::macros::Entry;
 #[cfg(not(feature = "derive_entry"))]
 use omnipaxos_core::storage::Entry;
+#[cfg(not(feature = "derive_entry"))]
 use omnipaxos_core::storage::Snapshot;
-#[cfg(feature = "derive_entry")]
-use omnipaxos_macros::Entry;
 use serde::{Deserialize, Serialize};
+#[cfg(not(feature = "derive_entry"))]
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/examples/kv_store/src/main.rs
+++ b/examples/kv_store/src/main.rs
@@ -1,8 +1,4 @@
-use crate::{
-    kv::{KVSnapshot, KeyValue},
-    server::OmniPaxosServer,
-    util::*,
-};
+use crate::{kv::KeyValue, server::OmniPaxosServer, util::*};
 use omnipaxos_core::{
     messages::Message,
     omni_paxos::*,
@@ -19,14 +15,14 @@ mod kv;
 mod server;
 mod util;
 
-type OmniPaxosKV = OmniPaxos<KeyValue, KVSnapshot, MemoryStorage<KeyValue, KVSnapshot>>;
+type OmniPaxosKV = OmniPaxos<KeyValue, MemoryStorage<KeyValue>>;
 
 const SERVERS: [u64; 3] = [1, 2, 3];
 
 #[allow(clippy::type_complexity)]
 fn initialise_channels() -> (
-    HashMap<NodeId, mpsc::Sender<Message<KeyValue, KVSnapshot>>>,
-    HashMap<NodeId, mpsc::Receiver<Message<KeyValue, KVSnapshot>>>,
+    HashMap<NodeId, mpsc::Sender<Message<KeyValue>>>,
+    HashMap<NodeId, mpsc::Receiver<Message<KeyValue>>>,
 ) {
     let mut sender_channels = HashMap::new();
     let mut receiver_channels = HashMap::new();

--- a/examples/kv_store/src/server.rs
+++ b/examples/kv_store/src/server.rs
@@ -1,4 +1,4 @@
-use crate::kv::{KVSnapshot, KeyValue};
+use crate::kv::KeyValue;
 use omnipaxos_core::{messages::Message, util::NodeId};
 use std::{
     collections::HashMap,
@@ -13,8 +13,8 @@ use tokio::{sync::mpsc, time};
 
 pub struct OmniPaxosServer {
     pub omni_paxos: Arc<Mutex<OmniPaxosKV>>,
-    pub incoming: mpsc::Receiver<Message<KeyValue, KVSnapshot>>,
-    pub outgoing: HashMap<NodeId, mpsc::Sender<Message<KeyValue, KVSnapshot>>>,
+    pub incoming: mpsc::Receiver<Message<KeyValue>>,
+    pub outgoing: HashMap<NodeId, mpsc::Sender<Message<KeyValue>>>,
 }
 
 impl OmniPaxosServer {

--- a/omnipaxos_core/Cargo.toml
+++ b/omnipaxos_core/Cargo.toml
@@ -5,6 +5,10 @@ authors = ["Harald Ng <hng@kth.se>"]
 edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 slog = { version = "2.7.0", optional = true }
 slog-term = { version = "2.9.0", optional = true }

--- a/omnipaxos_core/Cargo.toml
+++ b/omnipaxos_core/Cargo.toml
@@ -15,6 +15,7 @@ slog-term = { version = "2.9.0", optional = true }
 slog-async = { version = "2.7.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 toml = { version = "0.7.3", optional = true }
+omnipaxos_macros = { path = "../omnipaxos_macros", optional = true }
 
 [dev-dependencies]
 kompact = { git = "https://github.com/kompics/kompact", rev = "94956af", features = ["silent_logging"] }
@@ -33,6 +34,7 @@ continued_leader_reconfiguration = []
 logging  = ["slog", "slog-term", "slog-async"]
 toml_config = ["serde", "toml"]
 default = ["continued_leader_reconfiguration", "batch_accept"]
+macros = ["omnipaxos_macros"]
 
 [profile.release]
 lto = true

--- a/omnipaxos_core/src/lib.rs
+++ b/omnipaxos_core/src/lib.rs
@@ -30,3 +30,15 @@ pub mod storage;
 /// A module containing helper functions and structs.
 pub mod util;
 pub(crate) mod utils;
+
+#[cfg(feature = "macros")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate omnipaxos_macros;
+
+#[cfg(feature = "macros")]
+/// Macros in the omnipaxos crate
+pub mod macros {
+    #[doc(hidden)]
+    pub use omnipaxos_macros::*;
+}

--- a/omnipaxos_core/src/lib.rs
+++ b/omnipaxos_core/src/lib.rs
@@ -7,9 +7,11 @@
 //! The following crate feature flags are available. They are configured in your Cargo.toml.
 //! * `batch_accept` - Batch multiple log entries into a single message to reduce overhead.
 //! * `continued_leader_reconfiguration` - Let the cluster pick the current leader as the initial leader in the new configuration (if possible) to shorten down-time during reconfiguration.
-//! * `logging` - System-wide logging with the sled crate
+//! * `logging` - System-wide logging with the slog crate
 //! * `toml_config` - Create an OmniPaxos instance from a TOML configuration file
+//! * `serde` - Serialization and deserialization of messages and internal structs with serde. Disable this if you want to implement your own custom ser/deserialization or want to store data that is not serde-supported.
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 /// Trait and struct related to the leader election in Omni-Paxos.
 pub mod ballot_leader_election;

--- a/omnipaxos_core/src/messages.rs
+++ b/omnipaxos_core/src/messages.rs
@@ -1,6 +1,6 @@
 use crate::{
     messages::{ballot_leader_election::BLEMessage, sequence_paxos::PaxosMessage},
-    storage::{Entry, Snapshot},
+    storage::Entry,
     util::NodeId,
 };
 #[cfg(feature = "serde")]
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 pub mod sequence_paxos {
     use crate::{
         ballot_leader_election::Ballot,
-        storage::{Entry, Snapshot, SnapshotType, StopSign},
+        storage::{Entry, SnapshotType, StopSign},
         util::{NodeId, SequenceNumber},
     };
     #[cfg(feature = "serde")]
@@ -34,17 +34,16 @@ pub mod sequence_paxos {
     /// Promise message sent by a follower in response to a [`Prepare`] sent by the leader.
     #[derive(Clone, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct Promise<T, S>
+    pub struct Promise<T>
     where
         T: Entry,
-        S: Snapshot<T>,
     {
         /// The current round.
         pub n: Ballot,
         /// The latest round in which an entry was accepted.
         pub n_accepted: Ballot,
         /// The decided snapshot.
-        pub decided_snapshot: Option<SnapshotType<T, S>>,
+        pub decided_snapshot: Option<SnapshotType<T>>,
         /// The log suffix.
         pub suffix: Vec<T>,
         /// The decided index of this follower.
@@ -58,17 +57,16 @@ pub mod sequence_paxos {
     /// AcceptSync message sent by the leader to synchronize the logs of all replicas in the prepare phase.
     #[derive(Clone, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct AcceptSync<T, S>
+    pub struct AcceptSync<T>
     where
         T: Entry,
-        S: Snapshot<T>,
     {
         /// The current round.
         pub n: Ballot,
         /// The sequence number of this message in the leader-to-follower accept sequence
         pub seq_num: SequenceNumber,
         /// The decided snapshot.
-        pub decided_snapshot: Option<SnapshotType<T, S>>,
+        pub decided_snapshot: Option<SnapshotType<T>>,
         /// The log suffix.
         pub suffix: Vec<T>,
         /// The index of the log where the entries from `sync_item` should be applied at or the compacted idx
@@ -157,17 +155,16 @@ pub mod sequence_paxos {
     #[allow(missing_docs)]
     #[derive(Clone, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub enum PaxosMsg<T, S>
+    pub enum PaxosMsg<T>
     where
         T: Entry,
-        S: Snapshot<T>,
     {
         /// Request a [`Prepare`] to be sent from the leader. Used for fail-recovery.
         PrepareReq,
         #[allow(missing_docs)]
         Prepare(Prepare),
-        Promise(Promise<T, S>),
-        AcceptSync(AcceptSync<T, S>),
+        Promise(Promise<T>),
+        AcceptSync(AcceptSync<T>),
         AcceptDecide(AcceptDecide<T>),
         Accepted(Accepted),
         Decide(Decide),
@@ -183,17 +180,16 @@ pub mod sequence_paxos {
     /// A struct for a Paxos message that also includes sender and receiver.
     #[derive(Clone, Debug)]
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct PaxosMessage<T, S>
+    pub struct PaxosMessage<T>
     where
         T: Entry,
-        S: Snapshot<T>,
     {
         /// Sender of `msg`.
         pub from: NodeId,
         /// Receiver of `msg`.
         pub to: NodeId,
         /// The message content.
-        pub msg: PaxosMsg<T, S>,
+        pub msg: PaxosMsg<T>,
     }
 }
 
@@ -249,19 +245,17 @@ pub mod ballot_leader_election {
 /// Message in OmniPaxos. Can be either a `SequencePaxos` message (for log replication) or `BLE` message (for leader election)
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Message<T, S>
+pub enum Message<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
-    SequencePaxos(PaxosMessage<T, S>),
+    SequencePaxos(PaxosMessage<T>),
     BLE(BLEMessage),
 }
 
-impl<T, S> Message<T, S>
+impl<T> Message<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     /// Get the sender id of the message
     pub fn get_sender(&self) -> NodeId {

--- a/omnipaxos_core/src/omni_paxos.rs
+++ b/omnipaxos_core/src/omni_paxos.rs
@@ -53,7 +53,6 @@ impl OmniPaxosConfig {
     pub fn build<T, B>(self, storage: B) -> OmniPaxos<T, B>
     where
         T: Entry,
-
         B: Storage<T>,
     {
         assert_ne!(self.pid, 0, "Pid cannot be 0");
@@ -104,7 +103,6 @@ where
 impl<T, B> OmniPaxos<T, B>
 where
     T: Entry,
-
     B: Storage<T>,
 {
     /// Initiates the trim process.

--- a/omnipaxos_core/src/omni_paxos.rs
+++ b/omnipaxos_core/src/omni_paxos.rs
@@ -4,7 +4,7 @@ use crate::{
     ballot_leader_election::{Ballot, BallotLeaderElection},
     messages::Message,
     sequence_paxos::SequencePaxos,
-    storage::{Entry, Snapshot, StopSign, Storage},
+    storage::{Entry, StopSign, Storage},
     util::{defaults::BUFFER_SIZE, LogEntry, NodeId},
 };
 #[cfg(feature = "toml_config")]
@@ -50,11 +50,11 @@ impl OmniPaxosConfig {
     }
 
     /// Checks all configurations and returns the local OmniPaxos node if successful.
-    pub fn build<T, S, B>(self, storage: B) -> OmniPaxos<T, S, B>
+    pub fn build<T, B>(self, storage: B) -> OmniPaxos<T, B>
     where
         T: Entry,
-        S: Snapshot<T>,
-        B: Storage<T, S>,
+
+        B: Storage<T>,
     {
         assert_ne!(self.pid, 0, "Pid cannot be 0");
         assert_ne!(self.configuration_id, 0, "Configuration id cannot be 0");
@@ -92,21 +92,20 @@ impl Default for OmniPaxosConfig {
 
 /// The `OmniPaxos` struct represents an OmniPaxos server. Maintains the replicated log that can be read from and appended to.
 /// It also handles incoming messages and produces outgoing messages that you need to fetch and send periodically using your own network implementation.
-pub struct OmniPaxos<T, S, B>
+pub struct OmniPaxos<T, B>
 where
     T: Entry,
-    S: Snapshot<T>,
-    B: Storage<T, S>,
+    B: Storage<T>,
 {
-    seq_paxos: SequencePaxos<T, S, B>,
+    seq_paxos: SequencePaxos<T, B>,
     ble: BallotLeaderElection,
 }
 
-impl<T, S, B> OmniPaxos<T, S, B>
+impl<T, B> OmniPaxos<T, B>
 where
     T: Entry,
-    S: Snapshot<T>,
-    B: Storage<T, S>,
+
+    B: Storage<T>,
 {
     /// Initiates the trim process.
     /// # Arguments
@@ -158,7 +157,7 @@ where
     }
 
     /// Returns the outgoing messages from this replica. The messages should then be sent via the network implementation.
-    pub fn outgoing_messages(&mut self) -> Vec<Message<T, S>> {
+    pub fn outgoing_messages(&mut self) -> Vec<Message<T>> {
         let paxos_msgs = self
             .seq_paxos
             .get_outgoing_msgs()
@@ -173,7 +172,7 @@ where
     }
 
     /// Read entry at index `idx` in the log. Returns `None` if `idx` is out of bounds.
-    pub fn read(&self, idx: u64) -> Option<LogEntry<T, S>> {
+    pub fn read(&self, idx: u64) -> Option<LogEntry<T>> {
         match self.seq_paxos.internal_storage.read(idx..idx + 1) {
             Some(mut v) => v.pop(),
             None => None,
@@ -181,7 +180,7 @@ where
     }
 
     /// Read entries in the range `r` in the log. Returns `None` if `r` is out of bounds.
-    pub fn read_entries<R>(&self, r: R) -> Option<Vec<LogEntry<T, S>>>
+    pub fn read_entries<R>(&self, r: R) -> Option<Vec<LogEntry<T>>>
     where
         R: RangeBounds<u64>,
     {
@@ -189,14 +188,14 @@ where
     }
 
     /// Read all decided entries from `from_idx` in the log. Returns `None` if `from_idx` is out of bounds.
-    pub fn read_decided_suffix(&self, from_idx: u64) -> Option<Vec<LogEntry<T, S>>> {
+    pub fn read_decided_suffix(&self, from_idx: u64) -> Option<Vec<LogEntry<T>>> {
         self.seq_paxos
             .internal_storage
             .read_decided_suffix(from_idx)
     }
 
     /// Handle an incoming message.
-    pub fn handle_incoming(&mut self, m: Message<T, S>) {
+    pub fn handle_incoming(&mut self, m: Message<T>) {
         match m {
             Message::SequencePaxos(p) => self.seq_paxos.handle(p),
             Message::BLE(b) => self.ble.handle(b),

--- a/omnipaxos_core/src/sequence_paxos/follower.rs
+++ b/omnipaxos_core/src/sequence_paxos/follower.rs
@@ -6,11 +6,10 @@ use crate::{storage::SnapshotType, util::MessageStatus};
 #[cfg(feature = "logging")]
 use slog::warn;
 
-impl<T, S, B> SequencePaxos<T, S, B>
+impl<T, B> SequencePaxos<T, B>
 where
     T: Entry,
-    S: Snapshot<T>,
-    B: Storage<T, S>,
+    B: Storage<T>,
 {
     /*** Follower ***/
     pub(crate) fn handle_prepare(&mut self, prep: Prepare, from: NodeId) {
@@ -66,7 +65,7 @@ where
         }
     }
 
-    pub(crate) fn handle_acceptsync(&mut self, accsync: AcceptSync<T, S>, from: NodeId) {
+    pub(crate) fn handle_acceptsync(&mut self, accsync: AcceptSync<T>, from: NodeId) {
         if self.internal_storage.get_promise() == accsync.n
             && self.state == (Role::Follower, Phase::Prepare)
         {

--- a/omnipaxos_core/src/sequence_paxos/follower.rs
+++ b/omnipaxos_core/src/sequence_paxos/follower.rs
@@ -2,7 +2,10 @@ use super::super::ballot_leader_election::Ballot;
 
 use super::*;
 
-use crate::{storage::SnapshotType, util::MessageStatus};
+use crate::{
+    storage::{Snapshot, SnapshotType},
+    util::MessageStatus,
+};
 #[cfg(feature = "logging")]
 use slog::warn;
 
@@ -23,7 +26,7 @@ where
             let decided_idx = self.get_decided_idx();
             let (decided_snapshot, suffix) = if na > prep.n_accepted {
                 let ld = prep.decided_idx;
-                if ld < decided_idx && Self::use_snapshots() {
+                if ld < decided_idx && T::Snapshot::use_snapshots() {
                     let delta_snapshot =
                         self.internal_storage.create_diff_snapshot(ld, decided_idx);
                     let suffix = self.internal_storage.get_suffix(decided_idx);
@@ -34,7 +37,7 @@ where
                 }
             } else if na == prep.n_accepted && accepted_idx > prep.accepted_idx {
                 if self.internal_storage.get_compacted_idx() > prep.accepted_idx
-                    && Self::use_snapshots()
+                    && T::Snapshot::use_snapshots()
                 {
                     let delta_snapshot = self
                         .internal_storage

--- a/omnipaxos_core/src/sequence_paxos/follower.rs
+++ b/omnipaxos_core/src/sequence_paxos/follower.rs
@@ -16,7 +16,9 @@ where
 {
     /*** Follower ***/
     pub(crate) fn handle_prepare(&mut self, prep: Prepare, from: NodeId) {
-        if self.internal_storage.get_promise() <= prep.n {
+        if self.internal_storage.get_promise() < prep.n
+            || (self.internal_storage.get_promise() == prep.n && self.state.1 == Phase::Recover)
+        {
             self.leader = prep.n;
             self.internal_storage.set_promise(prep.n);
             self.state = (Role::Follower, Phase::Prepare);
@@ -81,7 +83,6 @@ where
                         SnapshotType::Delta(d) => {
                             self.internal_storage.merge_snapshot(accsync.decided_idx, d);
                         }
-                        _ => unimplemented!(),
                     }
                     let accepted_idx = self.internal_storage.append_entries(accsync.suffix);
                     Accepted {

--- a/omnipaxos_core/src/sequence_paxos/leader.rs
+++ b/omnipaxos_core/src/sequence_paxos/leader.rs
@@ -6,11 +6,10 @@ use crate::storage::SnapshotType;
 
 use super::*;
 
-impl<T, S, B> SequencePaxos<T, S, B>
+impl<T, B> SequencePaxos<T, B>
 where
     T: Entry,
-    S: Snapshot<T>,
-    B: Storage<T, S>,
+    B: Storage<T>,
 {
     /// Handle a new leader. Should be called when the leader election has elected a new leader with the ballot `n`
     /*** Leader ***/
@@ -400,7 +399,7 @@ where
         }
     }
 
-    pub(crate) fn handle_promise_prepare(&mut self, prom: Promise<T, S>, from: NodeId) {
+    pub(crate) fn handle_promise_prepare(&mut self, prom: Promise<T>, from: NodeId) {
         #[cfg(feature = "logging")]
         debug!(
             self.logger,
@@ -414,7 +413,7 @@ where
         }
     }
 
-    pub(crate) fn handle_promise_accept(&mut self, prom: Promise<T, S>, from: NodeId) {
+    pub(crate) fn handle_promise_accept(&mut self, prom: Promise<T>, from: NodeId) {
         #[cfg(feature = "logging")]
         {
             let (r, p) = &self.state;

--- a/omnipaxos_core/src/sequence_paxos/leader.rs
+++ b/omnipaxos_core/src/sequence_paxos/leader.rs
@@ -2,7 +2,7 @@ use super::super::{
     ballot_leader_election::Ballot,
     util::{LeaderState, PromiseData, PromiseMetaData},
 };
-use crate::storage::SnapshotType;
+use crate::storage::{Snapshot, SnapshotType};
 
 use super::*;
 
@@ -262,7 +262,7 @@ where
         let (delta_snapshot, suffix, sync_idx) =
             if (promise_n == max_promise_n) && (promise_accepted_idx < max_accepted_idx) {
                 if self.internal_storage.get_compacted_idx() > *promise_accepted_idx
-                    && Self::use_snapshots()
+                    && T::Snapshot::use_snapshots()
                 {
                     let delta_snapshot = self
                         .internal_storage
@@ -273,7 +273,7 @@ where
                     let sfx = self.internal_storage.get_suffix(*promise_accepted_idx);
                     (None, sfx, *promise_accepted_idx)
                 }
-            } else if follower_decided_idx < my_decided_idx && Self::use_snapshots() {
+            } else if follower_decided_idx < my_decided_idx && T::Snapshot::use_snapshots() {
                 let delta_snapshot = self
                     .internal_storage
                     .create_diff_snapshot(follower_decided_idx, my_decided_idx);

--- a/omnipaxos_core/src/sequence_paxos/leader.rs
+++ b/omnipaxos_core/src/sequence_paxos/leader.rs
@@ -359,7 +359,6 @@ where
                             SnapshotType::Delta(d) => {
                                 self.internal_storage.merge_snapshot(decided_idx, d);
                             }
-                            _ => unimplemented!(),
                         }
                         self.internal_storage.append_entries(suffix);
                         if let Some(ss) = max_stopsign {

--- a/omnipaxos_core/src/sequence_paxos/mod.rs
+++ b/omnipaxos_core/src/sequence_paxos/mod.rs
@@ -361,10 +361,6 @@ where
     fn get_stopsign(&self) -> Option<StopSign> {
         self.internal_storage.get_stopsign().map(|x| x.stopsign)
     }
-
-    pub(crate) fn use_snapshots() -> bool {
-        todo!()
-    }
 }
 
 #[derive(PartialEq, Debug)]

--- a/omnipaxos_core/src/storage.rs
+++ b/omnipaxos_core/src/storage.rs
@@ -13,8 +13,13 @@ use std::{
 
 /// Type of the entries stored in the log.
 pub trait Entry: Clone + Debug {
+    #[cfg(not(feature = "serde"))]
     /// The snapshot type for this entry type.
     type Snapshot: Snapshot<Self>;
+
+    #[cfg(feature = "serde")]
+    /// The snapshot type for this entry type.
+    type Snapshot: Snapshot<Self> + Serialize + for<'a> Deserialize<'a>;
 }
 
 /// A StopSign entry that marks the end of a configuration. Used for reconfiguration.
@@ -157,6 +162,7 @@ where
 
 /// A place holder type for when not using snapshots. You should not use this type, it is only internally when deriving the Entry implementation.
 #[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NoSnapshot;
 
 impl<T: Entry> Snapshot<T> for NoSnapshot {

--- a/omnipaxos_core/src/storage.rs
+++ b/omnipaxos_core/src/storage.rs
@@ -12,8 +12,17 @@ use std::{
 };
 
 /// Type of the entries stored in the log.
-pub trait Entry: Clone + Debug {}
-impl<T> Entry for T where T: Clone + Debug {}
+pub trait Entry: Clone + Debug {
+    /// The snapshot type for this entry type.
+    type Snapshot: Snapshot<Self>;
+}
+
+impl<T> Entry for T
+where
+    T: Clone + Debug,
+{
+    type Snapshot = ();
+}
 
 /// A StopSign entry that marks the end of a configuration. Used for reconfiguration.
 #[derive(Clone, Debug)]
@@ -63,18 +72,17 @@ impl PartialEq for StopSign {
 #[allow(missing_docs)]
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum SnapshotType<T, S>
+pub enum SnapshotType<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
-    Complete(S),
-    Delta(S),
+    Complete(T::Snapshot),
+    Delta(T::Snapshot),
     _Phantom(PhantomData<T>),
 }
 
 /// Functions required by Sequence Paxos to implement snapshot operations for `T`. If snapshot is not desired to be used, use the unit type `()` as the Snapshot parameter in `SequencePaxos`.
-pub trait Snapshot<T>: Clone
+pub trait Snapshot<T>: Clone + Debug
 where
     T: Entry,
 {
@@ -91,10 +99,9 @@ where
 }
 
 /// Trait for implementing the storage backend of Sequence Paxos.
-pub trait Storage<T, S>
+pub trait Storage<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     /// Appends an entry to the end of the log and returns the log length.
     fn append_entry(&mut self, entry: T) -> u64;
@@ -149,10 +156,10 @@ where
     fn get_compacted_idx(&self) -> u64;
 
     /// Sets the snapshot.
-    fn set_snapshot(&mut self, snapshot: S);
+    fn set_snapshot(&mut self, snapshot: T::Snapshot);
 
     /// Returns the stored snapshot.
-    fn get_snapshot(&self) -> Option<S>;
+    fn get_snapshot(&self) -> Option<T::Snapshot>;
 }
 
 #[allow(missing_docs)]
@@ -173,28 +180,24 @@ impl<T: Entry> Snapshot<T> for () {
 
 /// Internal representation of storage. Hides all complexities with the compacted index
 /// such that Sequence Paxos accesses the log with the uncompacted index.
-pub(crate) struct InternalStorage<I, T, S>
+pub(crate) struct InternalStorage<I, T>
 where
-    I: Storage<T, S>,
+    I: Storage<T>,
     T: Entry,
-    S: Snapshot<T>,
 {
     storage: I,
     _t: PhantomData<T>,
-    _i: PhantomData<S>,
 }
 
-impl<I, T, S> InternalStorage<I, T, S>
+impl<I, T> InternalStorage<I, T>
 where
-    I: Storage<T, S>,
+    I: Storage<T>,
     T: Entry,
-    S: Snapshot<T>,
 {
     pub(crate) fn with(storage: I) -> Self {
         InternalStorage {
             storage,
             _t: Default::default(),
-            _i: Default::default(),
         }
     }
 
@@ -219,7 +222,7 @@ where
     }
 
     /// Read entries in the range `r` in the log. Returns `None` if `r` is out of bounds.
-    pub(crate) fn read<R>(&self, r: R) -> Option<Vec<LogEntry<T, S>>>
+    pub(crate) fn read<R>(&self, r: R) -> Option<Vec<LogEntry<T>>>
     where
         R: RangeBounds<u64>,
     {
@@ -323,7 +326,7 @@ where
         to_sfx_idx: u64,
         compacted_idx: u64,
         decided_idx: u64,
-    ) -> Vec<LogEntry<T, S>> {
+    ) -> Vec<LogEntry<T>> {
         self.get_entries_with_real_idx(from_sfx_idx, to_sfx_idx)
             .into_iter()
             .enumerate()
@@ -339,7 +342,7 @@ where
     }
 
     /// Read all decided entries from `from_idx` in the log. Returns `None` if `from_idx` is out of bounds.
-    pub(crate) fn read_decided_suffix(&self, from_idx: u64) -> Option<Vec<LogEntry<T, S>>> {
+    pub(crate) fn read_decided_suffix(&self, from_idx: u64) -> Option<Vec<LogEntry<T>>> {
         let decided_idx = self.get_decided_idx();
         if from_idx < decided_idx {
             self.read(from_idx..decided_idx)
@@ -348,7 +351,7 @@ where
         }
     }
 
-    fn create_compacted_entry(&self, compacted_idx: u64) -> LogEntry<T, S> {
+    fn create_compacted_entry(&self, compacted_idx: u64) -> LogEntry<T> {
         match self.storage.get_snapshot() {
             Some(s) => LogEntry::Snapshotted(SnapshottedEntry::with(compacted_idx, s)),
             None => LogEntry::Trimmed(compacted_idx),
@@ -436,11 +439,11 @@ where
         self.storage.get_stopsign()
     }
 
-    pub(crate) fn create_snapshot(&mut self, compact_idx: u64) -> S {
+    pub(crate) fn create_snapshot(&mut self, compact_idx: u64) -> T::Snapshot {
         let entries = self
             .storage
             .get_entries(0, compact_idx - self.storage.get_compacted_idx());
-        let delta = S::create(entries.as_slice());
+        let delta = T::Snapshot::create(entries.as_slice());
         match self.storage.get_snapshot() {
             Some(mut s) => {
                 s.merge(delta);
@@ -450,20 +453,16 @@ where
         }
     }
 
-    pub(crate) fn create_diff_snapshot(
-        &mut self,
-        from_idx: u64,
-        to_idx: u64,
-    ) -> SnapshotType<T, S> {
+    pub(crate) fn create_diff_snapshot(&mut self, from_idx: u64, to_idx: u64) -> SnapshotType<T> {
         if self.get_compacted_idx() >= from_idx {
             SnapshotType::Complete(self.create_snapshot(to_idx))
         } else {
             let diff_entries = self.get_entries(from_idx, to_idx);
-            SnapshotType::Delta(S::create(diff_entries.as_slice()))
+            SnapshotType::Delta(T::Snapshot::create(diff_entries.as_slice()))
         }
     }
 
-    pub(crate) fn set_snapshot(&mut self, idx: u64, snapshot: S) {
+    pub(crate) fn set_snapshot(&mut self, idx: u64, snapshot: T::Snapshot) {
         let compacted_idx = self.storage.get_compacted_idx();
         if idx > compacted_idx {
             self.storage.trim(idx - compacted_idx);
@@ -472,7 +471,7 @@ where
         }
     }
 
-    pub(crate) fn merge_snapshot(&mut self, idx: u64, delta: S) {
+    pub(crate) fn merge_snapshot(&mut self, idx: u64, delta: T::Snapshot) {
         let mut snapshot = self
             .storage
             .get_snapshot()

--- a/omnipaxos_core/src/storage.rs
+++ b/omnipaxos_core/src/storage.rs
@@ -17,13 +17,6 @@ pub trait Entry: Clone + Debug {
     type Snapshot: Snapshot<Self>;
 }
 
-impl<T> Entry for T
-where
-    T: Clone + Debug,
-{
-    type Snapshot = ();
-}
-
 /// A StopSign entry that marks the end of a configuration. Used for reconfiguration.
 #[derive(Clone, Debug)]
 #[allow(missing_docs)]
@@ -162,15 +155,17 @@ where
     fn get_snapshot(&self) -> Option<T::Snapshot>;
 }
 
-#[allow(missing_docs)]
+/// A place holder type for when not using snapshots. You should not use this type, it is only internally when deriving the Entry implementation.
+#[derive(Clone, Debug)]
+pub struct NoSnapshot;
 
-impl<T: Entry> Snapshot<T> for () {
-    fn create(_: &[T]) -> Self {
-        unimplemented!()
+impl<T: Entry> Snapshot<T> for NoSnapshot {
+    fn create(_entries: &[T]) -> Self {
+        panic!("NoSnapshot should not be created");
     }
 
-    fn merge(&mut self, _: Self) {
-        unimplemented!()
+    fn merge(&mut self, _delta: Self) {
+        panic!("NoSnapshot should not be merged");
     }
 
     fn use_snapshots() -> bool {

--- a/omnipaxos_core/src/storage.rs
+++ b/omnipaxos_core/src/storage.rs
@@ -76,10 +76,9 @@ where
 {
     Complete(T::Snapshot),
     Delta(T::Snapshot),
-    _Phantom(PhantomData<T>),
 }
 
-/// Functions required by Sequence Paxos to implement snapshot operations for `T`. If snapshot is not desired to be used, use the unit type `()` as the Snapshot parameter in `SequencePaxos`.
+/// Trait for implementing snapshot operations for log entries of type `T` in OmniPaxos.
 pub trait Snapshot<T>: Clone + Debug
 where
     T: Entry,

--- a/omnipaxos_core/src/storage.rs
+++ b/omnipaxos_core/src/storage.rs
@@ -156,7 +156,7 @@ where
 }
 
 /// A place holder type for when not using snapshots. You should not use this type, it is only internally when deriving the Entry implementation.
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct NoSnapshot;
 
 impl<T: Entry> Snapshot<T> for NoSnapshot {

--- a/omnipaxos_core/src/util.rs
+++ b/omnipaxos_core/src/util.rs
@@ -1,7 +1,7 @@
 use super::{
     ballot_leader_election::Ballot,
     messages::sequence_paxos::Promise,
-    storage::{Entry, Snapshot, SnapshotType, StopSign},
+    storage::{Entry, SnapshotType, StopSign},
 };
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -41,16 +41,15 @@ impl PartialEq for PromiseMetaData {
 
 #[derive(Debug, Clone, Default)]
 /// Actual data of a promise i.e., the decided snapshot and/or the suffix.
-pub(crate) struct PromiseData<T: Entry, S: Snapshot<T>> {
-    pub decided_snapshot: Option<SnapshotType<T, S>>,
+pub(crate) struct PromiseData<T: Entry> {
+    pub decided_snapshot: Option<SnapshotType<T>>,
     pub suffix: Vec<T>,
 }
 
 #[derive(Debug, Clone, Default)]
-pub(crate) struct LeaderState<T, S>
+pub(crate) struct LeaderState<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     pub n_leader: Ballot,
     pub promises_meta: Vec<Option<PromiseMetaData>>,
@@ -59,7 +58,7 @@ where
     pub accepted_indexes: Vec<u64>,
     pub decided_indexes: Vec<Option<u64>>,
     pub max_promise_meta: PromiseMetaData,
-    pub max_promise: Option<PromiseData<T, S>>,
+    pub max_promise: Option<PromiseData<T>>,
     #[cfg(feature = "batch_accept")]
     pub batch_accept_meta: Vec<Option<(Ballot, usize)>>, //  index in outgoing
     pub accepted_stopsign: Vec<bool>,
@@ -67,10 +66,9 @@ where
     pub majority: usize,
 }
 
-impl<T, S> LeaderState<T, S>
+impl<T> LeaderState<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     pub fn with(
         n_leader: Ballot,
@@ -115,7 +113,7 @@ where
         self.decided_indexes[Self::pid_to_idx(pid)] = idx;
     }
 
-    pub fn set_promise(&mut self, prom: Promise<T, S>, from: u64, check_max_prom: bool) -> bool {
+    pub fn set_promise(&mut self, prom: Promise<T>, from: u64, check_max_prom: bool) -> bool {
         let promise_meta = PromiseMetaData {
             n: prom.n_accepted,
             accepted_idx: prom.accepted_idx,
@@ -135,7 +133,7 @@ where
         num_promised >= self.majority
     }
 
-    pub fn take_max_promise(&mut self) -> Option<PromiseData<T, S>> {
+    pub fn take_max_promise(&mut self) -> Option<PromiseData<T>> {
         std::mem::take(&mut self.max_promise)
     }
 
@@ -217,10 +215,9 @@ where
 
 /// The entry read in the log.
 #[derive(Debug, Clone)]
-pub enum LogEntry<T, S>
+pub enum LogEntry<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     /// The entry is decided.
     Decided(T),
@@ -229,7 +226,7 @@ where
     /// The entry has been trimmed.
     Trimmed(TrimmedIndex),
     /// The entry has been snapshotted.
-    Snapshotted(SnapshottedEntry<T, S>),
+    Snapshotted(SnapshottedEntry<T>),
     /// This Sequence Paxos instance has been stopped for reconfiguration.
     StopSign(StopSign),
 }
@@ -244,22 +241,20 @@ pub(crate) enum IndexEntry {
 
 #[allow(missing_docs)]
 #[derive(Debug, Clone)]
-pub struct SnapshottedEntry<T, S>
+pub struct SnapshottedEntry<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     pub trimmed_idx: TrimmedIndex,
-    pub snapshot: S,
+    pub snapshot: T::Snapshot,
     _p: PhantomData<T>,
 }
 
-impl<T, S> SnapshottedEntry<T, S>
+impl<T> SnapshottedEntry<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
-    pub(crate) fn with(trimmed_idx: u64, snapshot: S) -> Self {
+    pub(crate) fn with(trimmed_idx: u64, snapshot: T::Snapshot) -> Self {
         Self {
             trimmed_idx,
             snapshot,

--- a/omnipaxos_core/tests/consensus_test.rs
+++ b/omnipaxos_core/tests/consensus_test.rs
@@ -88,7 +88,7 @@ fn read_test() {
     let exp_snapshot = LatestValue::create(snapshotted);
 
     let temp_dir = create_temp_dir();
-    let mut storage = StorageType::<Value, LatestValue>::with(cfg.storage_type, &temp_dir);
+    let mut storage = StorageType::<Value>::with(cfg.storage_type, &temp_dir);
     storage.append_entries(log.clone());
     storage.set_decided_idx(decided_idx);
 
@@ -127,8 +127,7 @@ fn read_test() {
 
     // create stopped storage and SequencePaxos to test reading StopSign.
     let ss_temp_dir = create_temp_dir();
-    let mut stopped_storage =
-        StorageType::<Value, LatestValue>::with(cfg.storage_type, &ss_temp_dir);
+    let mut stopped_storage = StorageType::<Value>::with(cfg.storage_type, &ss_temp_dir);
     let ss = StopSign::with(2, vec![], None);
     let log_len = log.len() as u64;
     stopped_storage.append_entries(log.clone());
@@ -162,7 +161,7 @@ fn read_entries_test() {
     let exp_snapshot = LatestValue::create(snapshotted);
 
     let temp_dir = create_temp_dir();
-    let mut storage = StorageType::<Value, LatestValue>::with(cfg.storage_type, &temp_dir);
+    let mut storage = StorageType::<Value>::with(cfg.storage_type, &temp_dir);
     storage.append_entries(log.clone());
     storage.set_decided_idx(decided_idx);
 
@@ -208,8 +207,7 @@ fn read_entries_test() {
 
     // create stopped storage and SequencePaxos to test reading StopSign.
     let ss_temp_dir = create_temp_dir();
-    let mut stopped_storage =
-        StorageType::<Value, LatestValue>::with(cfg.storage_type, &ss_temp_dir);
+    let mut stopped_storage = StorageType::<Value>::with(cfg.storage_type, &ss_temp_dir);
     let ss = StopSign::with(2, vec![], None);
     let log_len = log.len() as u64;
     stopped_storage.append_entries(log.clone());

--- a/omnipaxos_core/tests/reconnect_test.rs
+++ b/omnipaxos_core/tests/reconnect_test.rs
@@ -6,7 +6,7 @@ use omnipaxos_core::{
 };
 use serial_test::serial;
 use std::{thread, time::Duration};
-use utils::{verification::verify_log, LatestValue, TestConfig, TestSystem, Value};
+use utils::{verification::verify_log, TestConfig, TestSystem, Value};
 
 const SLEEP_TIMEOUT: Duration = Duration::from_secs(1);
 const INITIAL_PROPOSALS: u64 = 5;
@@ -163,7 +163,7 @@ fn reconnect_to_leader_test() {
     thread::sleep(SLEEP_TIMEOUT);
 
     // Verify log
-    let followers_log: Vec<LogEntry<Value, LatestValue>> = follower.on_definition(|comp| {
+    let followers_log: Vec<LogEntry<Value>> = follower.on_definition(|comp| {
         comp.paxos
             .read_decided_suffix(0)
             .expect("Cannot read decided log entry")

--- a/omnipaxos_core/tests/recovery_test.rs
+++ b/omnipaxos_core/tests/recovery_test.rs
@@ -4,7 +4,7 @@ use kompact::prelude::{promise, Ask, FutureCollection, KFuture};
 use omnipaxos_core::util::LogEntry;
 use serial_test::serial;
 use std::{thread, time::Duration};
-use utils::{verification::verify_log, LatestValue, TestConfig, TestSystem, Value};
+use utils::{verification::verify_log, TestConfig, TestSystem, Value};
 
 const SLEEP_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -48,7 +48,7 @@ fn leader_fail_follower_propose_test() {
         .nodes
         .get(&leader)
         .expect("No SequencePaxos component found");
-    let read_log: Vec<LogEntry<Value, LatestValue>> = recovery_px.on_definition(|comp| {
+    let read_log: Vec<LogEntry<Value>> = recovery_px.on_definition(|comp| {
         comp.paxos
             .read_decided_suffix(0)
             .expect("Cannot read decided log entry")
@@ -102,7 +102,7 @@ fn leader_fail_leader_propose_test() {
         .nodes
         .get(&leader)
         .expect("No SequencePaxos component found");
-    let read_log: Vec<LogEntry<Value, LatestValue>> = recovery_px.on_definition(|comp| {
+    let read_log: Vec<LogEntry<Value>> = recovery_px.on_definition(|comp| {
         comp.paxos
             .read_decided_suffix(0)
             .expect("Cannot read decided log entry")
@@ -160,7 +160,7 @@ fn follower_fail_leader_propose_test() {
         .nodes
         .get(&leader)
         .expect("No SequencePaxos component found");
-    let read_log: Vec<LogEntry<Value, LatestValue>> = recovery_px.on_definition(|comp| {
+    let read_log: Vec<LogEntry<Value>> = recovery_px.on_definition(|comp| {
         comp.paxos
             .read_decided_suffix(0)
             .expect("Cannot read decided log entry")
@@ -218,7 +218,7 @@ fn follower_fail_follower_propose_test() {
         .nodes
         .get(&leader)
         .expect("No SequencePaxos component found");
-    let read_log: Vec<LogEntry<Value, LatestValue>> = recovery_px.on_definition(|comp| {
+    let read_log: Vec<LogEntry<Value>> = recovery_px.on_definition(|comp| {
         comp.paxos
             .read_decided_suffix(0)
             .expect("Cannot read decided log entry")

--- a/omnipaxos_core/tests/snapshot_test.rs
+++ b/omnipaxos_core/tests/snapshot_test.rs
@@ -172,7 +172,7 @@ fn double_snapshot_test() {
 
 fn check_snapshot(
     vec_proposals: Vec<Value>,
-    seq_after: Vec<(u64, Vec<LogEntry<Value, LatestValue>>)>,
+    seq_after: Vec<(u64, Vec<LogEntry<Value>>)>,
     gc_idx: u64,
     leader: NodeId,
 ) {

--- a/omnipaxos_core/tests/utils.rs
+++ b/omnipaxos_core/tests/utils.rs
@@ -88,19 +88,17 @@ impl StorageTypeSelector {
 
 /// An enum which can either be a 'PersistentStorage' or 'MemoryStorage', the type depends on the
 /// 'StorageTypeSelector' enum. Used for testing purposes with SequencePaxos and BallotLeaderElection.
-pub enum StorageType<T, S>
+pub enum StorageType<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
-    Persistent(PersistentStorage<T, S>),
-    Memory(MemoryStorage<T, S>),
+    Persistent(PersistentStorage<T>),
+    Memory(MemoryStorage<T>),
 }
 
-impl<T, S> StorageType<T, S>
+impl<T> StorageType<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     pub fn with(storage_type: StorageTypeSelector, my_path: &str) -> Self {
         match storage_type {
@@ -116,10 +114,10 @@ where
     }
 }
 
-impl<T, S> Storage<T, S> for StorageType<T, S>
+impl<T> Storage<T> for StorageType<T>
 where
     T: Entry + Serialize + for<'a> Deserialize<'a>,
-    S: Snapshot<T> + Serialize + for<'a> Deserialize<'a>,
+    T::Snapshot: Serialize + for<'a> Deserialize<'a>,
 {
     fn append_entry(&mut self, entry: T) -> u64 {
         match self {
@@ -240,14 +238,14 @@ where
         }
     }
 
-    fn set_snapshot(&mut self, snapshot: S) {
+    fn set_snapshot(&mut self, snapshot: T::Snapshot) {
         match self {
             StorageType::Persistent(persist_s) => persist_s.set_snapshot(snapshot),
             StorageType::Memory(mem_s) => mem_s.set_snapshot(snapshot),
         }
     }
 
-    fn get_snapshot(&self) -> Option<S> {
+    fn get_snapshot(&self) -> Option<T::Snapshot> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_snapshot(),
             StorageType::Memory(mem_s) => mem_s.get_snapshot(),
@@ -284,7 +282,7 @@ impl TestSystem {
         let mut nodes = HashMap::new();
 
         let all_pids: Vec<u64> = (1..=num_nodes as u64).collect();
-        let mut omni_refs: HashMap<u64, ActorRef<Message<Value, LatestValue>>> = HashMap::new();
+        let mut omni_refs: HashMap<u64, ActorRef<Message<Value>>> = HashMap::new();
 
         for pid in 1..=num_nodes as u64 {
             let peers: Vec<u64> = all_pids.iter().filter(|id| id != &&pid).cloned().collect();
@@ -292,7 +290,7 @@ impl TestSystem {
             op_config.pid = pid;
             op_config.peers = peers;
             op_config.configuration_id = 1;
-            let storage: StorageType<Value, LatestValue> =
+            let storage: StorageType<Value> =
                 StorageType::with(storage_type, &format!("{temp_dir_path}{pid}"));
             let (omni_replica, omni_reg_f) = system.create_and_register(|| {
                 OmniPaxosComponent::with(
@@ -359,12 +357,12 @@ impl TestSystem {
         storage_path: &str,
     ) {
         let peers: Vec<u64> = (1..=num_nodes as u64).filter(|id| id != &pid).collect();
-        let mut omni_refs: HashMap<u64, ActorRef<Message<Value, LatestValue>>> = HashMap::new();
+        let mut omni_refs: HashMap<u64, ActorRef<Message<Value>>> = HashMap::new();
         let mut op_config = OmniPaxosConfig::default();
         op_config.pid = pid;
         op_config.peers = peers;
         op_config.configuration_id = 1;
-        let storage: StorageType<Value, LatestValue> =
+        let storage: StorageType<Value> =
             StorageType::with(storage_type, &format!("{storage_path}{pid}"));
         let (omni_replica, omni_reg_f) = self
             .kompact_system
@@ -493,11 +491,11 @@ pub mod omnireplica {
         ctx: ComponentContext<Self>,
         #[allow(dead_code)]
         pid: NodeId,
-        pub peers: HashMap<u64, ActorRef<Message<Value, LatestValue>>>,
+        pub peers: HashMap<u64, ActorRef<Message<Value>>>,
         pub peer_disconnections: HashSet<u64>,
         paxos_timer: Option<ScheduledTimer>,
         tick_timer: Option<ScheduledTimer>,
-        pub paxos: OmniPaxos<Value, LatestValue, StorageType<Value, LatestValue>>,
+        pub paxos: OmniPaxos<Value, StorageType<Value>>,
         pub decided_futures: Vec<Ask<(), Value>>,
         pub election_futures: Vec<Ask<(), Ballot>>,
         current_leader_ballot: Ballot,
@@ -544,7 +542,7 @@ pub mod omnireplica {
     impl OmniPaxosComponent {
         pub fn with(
             pid: NodeId,
-            paxos: OmniPaxos<Value, LatestValue, StorageType<Value, LatestValue>>,
+            paxos: OmniPaxos<Value, StorageType<Value>>,
             election_timeout: Duration,
         ) -> Self {
             Self {
@@ -592,7 +590,7 @@ pub mod omnireplica {
             }
         }
 
-        pub fn set_peers(&mut self, peers: HashMap<u64, ActorRef<Message<Value, LatestValue>>>) {
+        pub fn set_peers(&mut self, peers: HashMap<u64, ActorRef<Message<Value>>>) {
             self.peers = peers;
         }
 
@@ -656,7 +654,7 @@ pub mod omnireplica {
     }
 
     impl Actor for OmniPaxosComponent {
-        type Message = Message<Value, LatestValue>;
+        type Message = Message<Value>;
 
         fn receive_local(&mut self, msg: Self::Message) -> Handled {
             self.paxos.handle_incoming(msg);
@@ -693,6 +691,10 @@ impl Snapshot<Value> for LatestValue {
     }
 }
 
+impl Entry for Value {
+    type Snapshot = LatestValue;
+}
+
 fn stopsign_meta_to_value(ss: &StopSign) -> Value {
     let v = ss
         .metadata
@@ -722,11 +724,7 @@ pub mod verification {
     /// * All entries are decided, verify the decided entries
     /// * Only a snapshot was taken, verify the snapshot
     /// * A snapshot was taken and entries decided on afterwards, verify both the snapshot and entries
-    pub fn verify_log(
-        read_log: Vec<LogEntry<Value, LatestValue>>,
-        proposals: Vec<Value>,
-        num_proposals: u64,
-    ) {
+    pub fn verify_log(read_log: Vec<LogEntry<Value>>, proposals: Vec<Value>, num_proposals: u64) {
         match &read_log[..] {
             [LogEntry::Decided(_), ..] => verify_entries(&read_log, &proposals, 0, num_proposals),
             [LogEntry::Snapshotted(s)] => {
@@ -747,7 +745,7 @@ pub mod verification {
 
     /// Verify that the log has a single snapshot of the latest entry.
     pub fn verify_snapshot(
-        read_entries: &[LogEntry<Value, LatestValue>],
+        read_entries: &[LogEntry<Value>],
         exp_compacted_idx: u64,
         exp_snapshot: &LatestValue,
     ) {
@@ -773,7 +771,7 @@ pub mod verification {
 
     /// Verify that all log entries are decided and matches the proposed entries.
     pub fn verify_entries(
-        read_entries: &[LogEntry<Value, LatestValue>],
+        read_entries: &[LogEntry<Value>],
         exp_entries: &[Value],
         offset: u64,
         decided_idx: u64,
@@ -802,7 +800,7 @@ pub mod verification {
     }
 
     /// Verify that the log entry contains only a stopsign matching `exp_stopsign`
-    pub fn verify_stopsign(read_entries: &[LogEntry<Value, LatestValue>], exp_stopsign: &StopSign) {
+    pub fn verify_stopsign(read_entries: &[LogEntry<Value>], exp_stopsign: &StopSign) {
         assert_eq!(
             read_entries.len(),
             1,

--- a/omnipaxos_macros/Cargo.toml
+++ b/omnipaxos_macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "omnipaxos_macros"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"

--- a/omnipaxos_macros/Cargo.toml
+++ b/omnipaxos_macros/Cargo.toml
@@ -13,5 +13,5 @@ syn = "1.0"
 quote = "1.0"
 
 [dev-dependencies]
-omnipaxos_core = { path = "../omnipaxos_core" }
+omnipaxos_core = { path = "../omnipaxos_core", features = ["macros"] }
 omnipaxos_storage = { path = "../omnipaxos_storage" }

--- a/omnipaxos_macros/Cargo.toml
+++ b/omnipaxos_macros/Cargo.toml
@@ -11,3 +11,7 @@ proc-macro = true
 [dependencies]
 syn = "1.0"
 quote = "1.0"
+
+[dev-dependencies]
+omnipaxos_core = { path = "../omnipaxos_core" }
+omnipaxos_storage = { path = "../omnipaxos_storage" }

--- a/omnipaxos_macros/src/lib.rs
+++ b/omnipaxos_macros/src/lib.rs
@@ -2,6 +2,18 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
 
+/// Derive macro for declaring an OmniPaxos log entry type that does not use snapshots.
+///
+/// ## Usage
+///
+/// ```rust
+/// use omnipaxos_core::macros::Entry;
+/// #[derive(Clone, Debug, Entry)]
+/// pub struct KeyValue {
+///     pub key: String,
+///     pub value: u64,
+/// }
+/// ```
 #[proc_macro_derive(Entry)]
 pub fn entry_derive(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree

--- a/omnipaxos_macros/src/lib.rs
+++ b/omnipaxos_macros/src/lib.rs
@@ -1,0 +1,22 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(Entry)]
+pub fn entry_derive(input: TokenStream) -> TokenStream {
+    // Parse the input tokens into a syntax tree
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    // Get the name of the struct we're deriving Entry for
+    let name = &ast.ident;
+    // Generate the implementation of Entry using the quote! macro
+    let gen = quote! {
+        impl ::omnipaxos_core::storage::Entry for #name
+        {
+            type Snapshot = ::omnipaxos_core::storage::NoSnapshot;
+        }
+    };
+
+    // Convert the generated code back into tokens and return them
+    gen.into()
+}

--- a/omnipaxos_macros/tests/derive_test.rs
+++ b/omnipaxos_macros/tests/derive_test.rs
@@ -1,8 +1,7 @@
-#[macro_use]
-extern crate omnipaxos_macros;
-
 #[test]
 fn derive_entry_test() {
+    use omnipaxos_core::macros::Entry;
+
     #[derive(Clone, Debug, Entry)]
     struct TestEntry {
         pub _field1: u64,
@@ -12,7 +11,10 @@ fn derive_entry_test() {
 
 #[test]
 fn build_op_test() {
-    use omnipaxos_core::omni_paxos::{OmniPaxos, OmniPaxosConfig};
+    use omnipaxos_core::{
+        macros::Entry,
+        omni_paxos::{OmniPaxos, OmniPaxosConfig},
+    };
     use omnipaxos_storage::memory_storage::MemoryStorage;
 
     #[derive(Clone, Debug, Entry)]

--- a/omnipaxos_macros/tests/derive_test.rs
+++ b/omnipaxos_macros/tests/derive_test.rs
@@ -3,6 +3,15 @@ extern crate omnipaxos_macros;
 
 #[test]
 fn derive_entry_test() {
+    #[derive(Clone, Debug, Entry)]
+    struct TestEntry {
+        pub _field1: u64,
+        pub _field2: String,
+    }
+}
+
+#[test]
+fn build_op_test() {
     use omnipaxos_core::omni_paxos::{OmniPaxos, OmniPaxosConfig};
     use omnipaxos_storage::memory_storage::MemoryStorage;
 

--- a/omnipaxos_macros/tests/derive_test.rs
+++ b/omnipaxos_macros/tests/derive_test.rs
@@ -1,0 +1,24 @@
+#[macro_use]
+extern crate omnipaxos_macros;
+
+#[test]
+fn derive_entry_test() {
+    use omnipaxos_core::omni_paxos::{OmniPaxos, OmniPaxosConfig};
+    use omnipaxos_storage::memory_storage::MemoryStorage;
+
+    #[derive(Clone, Debug, Entry)]
+    struct TestEntry {
+        pub _field1: u64,
+        pub _field2: String,
+    }
+
+    let config = OmniPaxosConfig {
+        configuration_id: 1,
+        pid: 1,
+        peers: vec![2, 3],
+        ..Default::default()
+    };
+
+    let _omnipaxos: OmniPaxos<TestEntry, MemoryStorage<TestEntry>> =
+        config.build(MemoryStorage::default());
+}

--- a/omnipaxos_storage/Cargo.toml
+++ b/omnipaxos_storage/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 authors = ["Abyel Tesfay <abyel@kth.se>", "Harald Ng <hng@kth.se>"]
 edition = "2018"
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 omnipaxos_core = { path = "../omnipaxos_core" }
 rocksdb = { version = "0.18.0", optional = true }
@@ -20,3 +24,6 @@ sled = ["dep:sled"]
 rocksdb = ["dep:rocksdb"]
 
 default = ["sled"]
+
+[profile.release]
+lto = true

--- a/omnipaxos_storage/src/lib.rs
+++ b/omnipaxos_storage/src/lib.rs
@@ -1,7 +1,9 @@
 //! A library of storage implementations for SequencePaxos
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(missing_docs)]
 /// an in-memory storage implementation with fast read and writes
 pub mod memory_storage;
+
 /// an on-disk storage implementation with persistence for the replica state and the log.
 pub mod persistent_storage;

--- a/omnipaxos_storage/src/memory_storage.rs
+++ b/omnipaxos_storage/src/memory_storage.rs
@@ -1,13 +1,12 @@
 use omnipaxos_core::{
     ballot_leader_election::Ballot,
-    storage::{Entry, Snapshot, StopSignEntry, Storage},
+    storage::{Entry, StopSignEntry, Storage},
 };
 /// An in-memory storage implementation for SequencePaxos.
 #[derive(Clone)]
-pub struct MemoryStorage<T, S>
+pub struct MemoryStorage<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     /// Vector which contains all the logged entries in-memory.
     log: Vec<T>,
@@ -20,15 +19,14 @@ where
     /// Garbage collected index.
     trimmed_idx: u64,
     /// Stored snapshot
-    snapshot: Option<S>,
+    snapshot: Option<T::Snapshot>,
     /// Stored StopSign
     stopsign: Option<StopSignEntry>,
 }
 
-impl<T, S> Storage<T, S> for MemoryStorage<T, S>
+impl<T> Storage<T> for MemoryStorage<T>
 where
     T: Entry,
-    S: Snapshot<T>,
 {
     fn append_entry(&mut self, entry: T) -> u64 {
         self.log.push(entry);
@@ -109,16 +107,16 @@ where
         self.trimmed_idx
     }
 
-    fn set_snapshot(&mut self, snapshot: S) {
+    fn set_snapshot(&mut self, snapshot: T::Snapshot) {
         self.snapshot = Some(snapshot);
     }
 
-    fn get_snapshot(&self) -> Option<S> {
+    fn get_snapshot(&self) -> Option<T::Snapshot> {
         self.snapshot.clone()
     }
 }
 
-impl<T: Entry, S: Snapshot<T>> Default for MemoryStorage<T, S> {
+impl<T: Entry> Default for MemoryStorage<T> {
     fn default() -> Self {
         Self {
             log: vec![],


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Issues
Remove awkward Snapshot generic type and fix #74 

This PR aims to improve usability by getting rid of one of the many generic types we have. This makes writing Storage and OmniPaxos a lot less verbose, i.e.,
`OmniPaxos<Entry, MemoryStorage<Entry>>` instead of `OmniPaxos<Entry, Snapshot, MemoryStorage<Entry, Snapshot>>`
## Breaking Changes
- OmniPaxos and all structs that had `<T: Entry, S: Snapshot>` as generic types are now replaced with `<T: Entry>`. Instead the `Entry` trait now has an associated type `Storage`. So all usages of `S` in the  API has been replaced  with `T::Snapshot`.
- Removed the blanket implementation for `Entry` for all types that implemented `Clone + Debug`. To implement Entry, the user can derive it using `omnipaxos_macros::Entry`, or implement it manually if they want to use snapshots.

## Other Changes
- Updated documentation, examples, and all-things related to this API change. Also added documentation for feature flags.
- Added the workspace `omnipaxos_macros` and tests for it.
