### PR TITLE
Refactor in favour of single source of truth for stopsign decidedness

### DIFF
--- a/omnipaxos/src/messages.rs
+++ b/omnipaxos/src/messages.rs
@@ -128,24 +128,6 @@ pub mod sequence_paxos {
         pub ss: StopSign,
     }
 
-    /// Message sent by followers to leader when accepted StopSign
-    #[derive(Copy, Clone, Debug)]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct AcceptedStopSign {
-        /// The current round.
-        pub n: Ballot,
-    }
-
-    /// Message sent by leader to decide a StopSign
-    #[derive(Copy, Clone, Debug)]
-    #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-    pub struct DecideStopSign {
-        /// The current round.
-        pub n: Ballot,
-        /// The sequence number of this message in the leader-to-follower accept sequence
-        pub seq_num: SequenceNumber,
-    }
-
     /// Compaction Request
     #[allow(missing_docs)]
     #[derive(Clone, Debug)]
@@ -176,8 +158,6 @@ pub mod sequence_paxos {
         ProposalForward(Vec<T>),
         Compaction(Compaction),
         AcceptStopSign(AcceptStopSign),
-        AcceptedStopSign(AcceptedStopSign),
-        DecideStopSign(DecideStopSign),
         ForwardStopSign(StopSign),
     }
 

--- a/omnipaxos/src/sequence_paxos/follower.rs
+++ b/omnipaxos/src/sequence_paxos/follower.rs
@@ -183,13 +183,7 @@ where
                     } else {
                         self.accept_stopsign(ss);
                     }
-                    let ss_idx = self
-                        .internal_storage
-                        .get_stopsign()
-                        .expect("stopsign should have been accepted")
-                        .log_idx;
-                    assert_eq!(ss_idx, accepted.accepted_idx);
-                    accepted.accepted_idx = ss_idx + 1;
+                    accepted.accepted_idx = self.internal_storage.get_accepted_idx();
                 }
                 None => self.forward_pending_proposals(),
             }
@@ -241,16 +235,9 @@ where
             && self.handle_sequence_num(acc_ss.seq_num, acc_ss.n.pid) == MessageStatus::Expected
         {
             self.accept_stopsign(acc_ss.ss);
-            let ss_idx = self
-                .internal_storage
-                .get_stopsign()
-                .expect("stopsign not accepted")
-                .log_idx;
-            let accepted_idx = self.internal_storage.get_accepted_idx();
-            assert_eq!(ss_idx + 1, accepted_idx);
             let a = Accepted {
                 n: acc_ss.n,
-                accepted_idx,
+                accepted_idx: self.internal_storage.get_accepted_idx(),
             };
             self.outgoing.push(PaxosMessage {
                 from: self.pid,

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -43,8 +43,8 @@ where
             let decided_idx = self.get_decided_idx();
             let accepted_idx = self
                 .internal_storage
-                .get_log_len()
-                .expect("storage error while trying to read log length");
+                .get_accepted_idx()
+                .expect("storage error while trying to read accepted_idx");
             let my_promise = Promise {
                 n,
                 n_accepted: na,
@@ -169,7 +169,7 @@ where
             n: self.leader_state.n_leader,
             decided_idx: self.internal_storage.get_decided_idx()?,
             n_accepted: self.internal_storage.get_accepted_round()?,
-            accepted_idx: self.internal_storage.get_log_len()?,
+            accepted_idx: self.internal_storage.get_accepted_idx()?,
         };
         self.outgoing.push(PaxosMessage {
             from: self.pid,

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -402,13 +402,14 @@ where
     }
 
     fn accept_stopsign(&mut self, ss: StopSign) {
-        let accepted_idx = self.internal_storage.get_accepted_idx();
+        let ss_log_idx = self.internal_storage.get_accepted_idx();
         self.internal_storage
-            .set_stopsign(StopSignEntry::with(ss, accepted_idx))
+            .set_stopsign(StopSignEntry::with(ss, ss_log_idx))
             .expect("storage error while trying to write stopsign");
+        let accepted_idx = self.internal_storage.get_accepted_idx();
+        assert_eq!(accepted_idx, ss_log_idx + 1);
         if self.state.0 == Role::Leader {
-            self.leader_state
-                .set_accepted_idx(self.pid, accepted_idx + 1);
+            self.leader_state.set_accepted_idx(self.pid, accepted_idx);
         }
     }
 

--- a/omnipaxos/src/storage.rs
+++ b/omnipaxos/src/storage.rs
@@ -28,18 +28,22 @@ pub trait Entry: Clone + Debug {
 #[allow(missing_docs)]
 pub struct StopSignEntry {
     pub stopsign: StopSign,
-    pub idx: u64,
+    /// The log index of the StopSign
+    pub log_idx: u64,
 }
 
 impl StopSignEntry {
     /// Creates a [`StopSign`].
     pub fn with(stopsign: StopSign, idx: u64) -> Self {
-        StopSignEntry { stopsign, idx }
+        StopSignEntry {
+            stopsign,
+            log_idx: idx,
+        }
     }
 
     /// Checks if the stopsign is decided.
     pub fn decided(&self, decided_idx: u64) -> bool {
-        self.idx < decided_idx
+        self.log_idx < decided_idx
     }
 }
 

--- a/omnipaxos/src/storage.rs
+++ b/omnipaxos/src/storage.rs
@@ -237,11 +237,12 @@ where
 
     // Returns the index of the last accepted entry.
     fn get_accepted_idx(&self) -> u64 {
-        let mut idx = self.compacted_idx + self.real_log_len;
+        let log_len = self.compacted_idx + self.real_log_len;
         if self.stopsign.is_some() {
-            idx += 1;
+            log_len + 1
+        } else {
+            log_len
         }
-        idx
     }
 
     // Appends an entry to the end of the `batched_entries`. If the batch is full, the
@@ -384,10 +385,7 @@ where
         } else if idx == virtual_log_len {
             match self.get_stopsign() {
                 Some(ss) => Ok(Some(IndexEntry::StopSign(ss.stopsign))),
-                _ => {
-                    println!("HELLLOOO");
-                    Ok(None)
-                }
+                _ => Ok(None),
             }
         } else {
             Ok(None)
@@ -417,17 +415,11 @@ where
                 return Ok(Some(vec![self.create_compacted_entry(compacted_idx)?]))
             }
             Some(from_type) => from_type,
-            x => {
-                println!("TO {:?}", x);
-                return Ok(None);
-            }
+            _ => return Ok(None),
         };
         let from_type = match self.get_entry_type(from_idx, compacted_idx, log_len)? {
             Some(from_type) => from_type,
-            x => {
-                println!("TO {:?}", x);
-                return Ok(None);
-            }
+            _ => return Ok(None),
         };
         let decided_idx = self.get_decided_idx();
         match (from_type, to_type) {

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -61,7 +61,6 @@ where
     pub max_promise: Option<PromiseData<T>>,
     #[cfg(feature = "batch_accept")]
     pub batch_accept_meta: Vec<Option<(Ballot, usize)>>, //  index in outgoing
-    pub accepted_stopsign: Vec<bool>,
     pub max_pid: usize,
     pub majority: usize,
 }
@@ -86,7 +85,6 @@ where
             max_promise: None,
             #[cfg(feature = "batch_accept")]
             batch_accept_meta: vec![None; max_pid],
-            accepted_stopsign: vec![false; max_pid],
             max_pid,
             majority,
         }
@@ -143,14 +141,6 @@ where
 
     pub fn get_max_promise_meta(&self) -> &PromiseMetaData {
         &self.max_promise_meta
-    }
-
-    pub fn set_accepted_stopsign(&mut self, from: NodeId) {
-        self.accepted_stopsign[Self::pid_to_idx(from)] = true;
-    }
-
-    pub fn follower_has_accepted_stopsign(&mut self, from: NodeId) -> bool {
-        self.accepted_stopsign[Self::pid_to_idx(from)]
     }
 
     pub fn get_promise_meta(&self, pid: NodeId) -> &PromiseMetaData {
@@ -212,9 +202,8 @@ where
         self.decided_indexes.get(Self::pid_to_idx(pid)).unwrap()
     }
 
-    pub fn is_stopsign_chosen(&self) -> bool {
-        let num_accepted = self.accepted_stopsign.iter().filter(|x| **x).count();
-        num_accepted >= self.majority
+    pub fn get_accepted_idx(&self, pid: NodeId) -> u64 {
+        *self.accepted_indexes.get(Self::pid_to_idx(pid)).unwrap()
     }
 
     pub fn is_chosen(&self, idx: u64) -> bool {

--- a/omnipaxos/tests/atomic_storage_test.rs
+++ b/omnipaxos/tests/atomic_storage_test.rs
@@ -229,7 +229,8 @@ fn atomic_storage_decide_stopsign_test() {
         // check consistency
         let s = mem_storage.lock().unwrap();
         let new_decided_idx = s.get_decided_idx().unwrap();
-        let ss_decided = s.get_stopsign().unwrap().unwrap().decided;
+        let ss = s.get_stopsign().unwrap().unwrap();
+        let ss_decided = ss.decided(new_decided_idx);
         assert!(
             (!ss_decided && new_decided_idx == old_decided_idx)
                 || (ss_decided && new_decided_idx == old_decided_idx + 1),
@@ -608,12 +609,12 @@ fn atomic_storage_majority_accepted_stopsign_test() {
         let new_decided_idx = s.get_decided_idx().unwrap();
         let new_stopsign = s.get_stopsign().unwrap().unwrap();
         assert!(
-            !old_stopsign.decided,
+            !old_stopsign.decided(old_decided_idx),
             "sanity check failed: newly proposed stopsign is decided"
         );
         assert!(
-            (new_decided_idx == old_decided_idx && !new_stopsign.decided)
-                || (new_decided_idx > old_decided_idx && new_stopsign.decided),
+            (new_decided_idx == old_decided_idx && !new_stopsign.decided(new_decided_idx))
+                || (new_decided_idx > old_decided_idx && new_stopsign.decided(new_decided_idx)),
             "decided_idx and decided_stopsign should be updated atomically"
         );
     }

--- a/omnipaxos/tests/consensus_test.rs
+++ b/omnipaxos/tests/consensus_test.rs
@@ -90,8 +90,8 @@ fn read_test() {
 
     let temp_dir = create_temp_dir();
     let mut storage = StorageType::<Value>::with(cfg.storage_type, &temp_dir);
-    storage.append_entries(log.clone());
-    storage.set_decided_idx(decided_idx);
+    storage.append_entries(log.clone()).unwrap();
+    storage.set_decided_idx(decided_idx).unwrap();
 
     let mut op_config = OmniPaxosConfig::default();
     op_config.pid = 1;
@@ -131,9 +131,11 @@ fn read_test() {
     let mut stopped_storage = StorageType::<Value>::with(cfg.storage_type, &ss_temp_dir);
     let ss = StopSign::with(2, vec![], None);
     let log_len = log.len() as u64;
-    stopped_storage.append_entries(log.clone());
-    stopped_storage.set_stopsign(StopSignEntry::with(ss.clone(), true));
-    stopped_storage.set_decided_idx(log_len);
+    stopped_storage.append_entries(log.clone()).unwrap();
+    stopped_storage
+        .set_stopsign(StopSignEntry::with(ss.clone(), log_len))
+        .unwrap();
+    stopped_storage.set_decided_idx(log_len + 1).unwrap();
 
     let mut stopped_op = op_config.build(stopped_storage);
     stopped_op
@@ -163,8 +165,8 @@ fn read_entries_test() {
 
     let temp_dir = create_temp_dir();
     let mut storage = StorageType::<Value>::with(cfg.storage_type, &temp_dir);
-    storage.append_entries(log.clone());
-    storage.set_decided_idx(decided_idx);
+    storage.append_entries(log.clone()).unwrap();
+    storage.set_decided_idx(decided_idx).unwrap();
 
     let mut op_config = OmniPaxosConfig::default();
     op_config.pid = 1;
@@ -211,9 +213,11 @@ fn read_entries_test() {
     let mut stopped_storage = StorageType::<Value>::with(cfg.storage_type, &ss_temp_dir);
     let ss = StopSign::with(2, vec![], None);
     let log_len = log.len() as u64;
-    stopped_storage.append_entries(log.clone());
-    stopped_storage.set_stopsign(StopSignEntry::with(ss.clone(), true));
-    stopped_storage.set_decided_idx(log_len);
+    stopped_storage.append_entries(log.clone()).unwrap();
+    stopped_storage
+        .set_stopsign(StopSignEntry::with(ss.clone(), log_len))
+        .unwrap();
+    stopped_storage.set_decided_idx(log_len + 1).unwrap();
 
     let mut stopped_op = op_config.build(stopped_storage);
     stopped_op

--- a/omnipaxos_storage/src/persistent_storage.rs
+++ b/omnipaxos_storage/src/persistent_storage.rs
@@ -53,14 +53,14 @@ impl BallotStorage {
 #[derive(Clone, Serialize, Deserialize)]
 struct StopSignEntryStorage {
     ss: StopSignStorage,
-    idx: u64,
+    log_idx: u64,
 }
 
 impl StopSignEntryStorage {
     fn with(ss_entry: StopSignEntry) -> Self {
         StopSignEntryStorage {
             ss: StopSignStorage::with(ss_entry.stopsign),
-            idx: ss_entry.idx,
+            log_idx: ss_entry.log_idx,
         }
     }
 }
@@ -513,7 +513,7 @@ where
                             ss_entry_storage.ss.nodes,
                             ss_entry_storage.ss.metadata,
                         ),
-                        ss_entry_storage.idx,
+                        ss_entry_storage.log_idx,
                     )))
                 }
                 None => Ok(None),

--- a/omnipaxos_storage/src/persistent_storage.rs
+++ b/omnipaxos_storage/src/persistent_storage.rs
@@ -53,14 +53,14 @@ impl BallotStorage {
 #[derive(Clone, Serialize, Deserialize)]
 struct StopSignEntryStorage {
     ss: StopSignStorage,
-    decided: bool,
+    idx: u64,
 }
 
 impl StopSignEntryStorage {
     fn with(ss_entry: StopSignEntry) -> Self {
         StopSignEntryStorage {
             ss: StopSignStorage::with(ss_entry.stopsign),
-            decided: ss_entry.decided,
+            idx: ss_entry.idx,
         }
     }
 }
@@ -495,7 +495,7 @@ where
                             ss_entry_storage.ss.nodes,
                             ss_entry_storage.ss.metadata,
                         ),
-                        ss_entry_storage.decided,
+                        ss_entry_storage.idx,
                     )))
                 }
                 None => Ok(None),
@@ -513,7 +513,7 @@ where
                             ss_entry_storage.ss.nodes,
                             ss_entry_storage.ss.metadata,
                         ),
-                        ss_entry_storage.decided,
+                        ss_entry_storage.idx,
                     )))
                 }
                 None => Ok(None),


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Issues
fixes #96 

## Breaking Changes
The `StopSignEntry` which is also read by the public API, does not contain a `decided` flag anymore, but instead an `idx`.
I don't think this is very noteworthy, since only decided `StopSign`s are read anyways. 
