### PR TITLE
Feature resend decide ss

### DIFF
--- a/docs/omnipaxos/flexible_quorums.md
+++ b/docs/omnipaxos/flexible_quorums.md
@@ -1,20 +1,26 @@
-OmniPaxos also offers support for [flexible quorums](https://arxiv.org/pdf/1608.06696v1.pdf). Normally a node needs to consult a majority of nodes to become a leader and then as a leader consult a majority of nodes to append to the log. Flexible quorums allow for a trade off between the number of nodes that need to be consulted in each of these two scenarios.
+OmniPaxos also offers support for [flexible quorums](https://arxiv.org/pdf/1608.06696v1.pdf). Normally a node needs to consult a majority of nodes to become a leader and then, as a leader, consult a majority of nodes to append to the log. Flexible quorums allow for a trade off between the number of nodes that need to be consulted in each of these two scenarios.
 
 OmniPaxos can be configured to use a flexible quorum as follows:
 ```rust
-use omnipaxos::{OmniPaxosConfig, util::FlexibleQuroum};
+use omnipaxos::{ClusterConfig, OmniPaxosConfig, ServerConfig, util::FlexibleQuroum};
 
 let flex_quorum = FlexibleQuorum {
     read_quorum_size: 5,
     write_quorum_size: 3,
 };
 
-let config = OmniPaxosConfig {
+let cluster_config = ClusterConfig {
     configuration_id: 1,
-    pid: 1,
-    peers: vec![2, 3, 4, 5, 6, 7],
+    nodes: vec![1, 2, 3, 4, 5, 6, 7],
     flexible_quorum: Some(flex_quorum),
-    ..Default::deafult()
+};
+let server_config = ServerConfig {
+    pid: 1,
+    ..Default::default()
+};
+let config = OmniPaxosConfig {
+    cluster_config,
+    server_config,
 };
 ```
 In OmniPaxos, becoming a leader involves reading from the log and so `read_quorum_size` is the number of nodes to consult in order to become a leader. The `write_quorum_size` is the number of nodes to consult in order to append to the log.

--- a/docs/omnipaxos/reconfiguration.md
+++ b/docs/omnipaxos/reconfiguration.md
@@ -21,7 +21,7 @@ let decided_entries: Option<Vec<LogEntry<KeyValue>>> = omnipaxos.  read_decided_
 if let Some(de) = decided_entries {
     for d in de {
         match d {
-            LogEntry::StopSign(stopsign) => {
+            LogEntry::StopSign(stopsign, _stopsign_is_decided) => {
                 let new_configuration = stopsign.next_config;
                 if new_configuration.nodes.contains(&my_pid) {
                 // current configuration has been safely stopped. Start new instance

--- a/docs/omnipaxos/reconfiguration.md
+++ b/docs/omnipaxos/reconfiguration.md
@@ -21,7 +21,7 @@ let decided_entries: Option<Vec<LogEntry<KeyValue>>> = omnipaxos.  read_decided_
 if let Some(de) = decided_entries {
     for d in de {
         match d {
-            LogEntry::StopSign(stopsign, _stopsign_is_decided) => {
+            LogEntry::StopSign(stopsign, true) => {
                 let new_configuration = stopsign.next_config;
                 if new_configuration.nodes.contains(&my_pid) {
                 // current configuration has been safely stopped. Start new instance

--- a/omnipaxos/src/ballot_leader_election.rs
+++ b/omnipaxos/src/ballot_leader_election.rs
@@ -37,12 +37,7 @@ impl Ballot {
     /// * `config_id` - The identifier for the configuration that the replica with this ballot is part of.
     /// * `n` - Ballot number.
     /// * `pid` -  Used as tiebreaker for total ordering of ballots.
-    pub fn with(
-        config_id: ConfigurationId,
-        n: ConfigurationId,
-        priority: u32,
-        pid: NodeId,
-    ) -> Ballot {
+    pub fn with(config_id: ConfigurationId, n: u32, priority: u32, pid: NodeId) -> Ballot {
         Ballot {
             config_id,
             n,
@@ -105,11 +100,7 @@ impl BallotLeaderElection {
         let peers = config.peers;
         let num_nodes = &peers.len() + 1;
         let quorum = Quorum::with(config.flexible_quorum, num_nodes);
-        let initial_ballot = match initial_leader {
-            Some(ballot) if ballot.pid == pid => ballot,
-            _ => Ballot::with(config_id, 0, config.priority, pid),
-        };
-
+        let initial_ballot = Ballot::with(config_id, 0, config.priority, pid);
         let mut ble = BallotLeaderElection {
             configuration_id: config_id,
             pid,

--- a/omnipaxos/src/messages.rs
+++ b/omnipaxos/src/messages.rs
@@ -73,6 +73,8 @@ pub mod sequence_paxos {
         pub sync_idx: u64,
         /// The decided index
         pub decided_idx: u64,
+        /// The accepted index
+        pub accepted_idx: u64,
         /// StopSign to be accepted
         pub stopsign: Option<StopSign>,
     }

--- a/omnipaxos/src/messages.rs
+++ b/omnipaxos/src/messages.rs
@@ -73,8 +73,8 @@ pub mod sequence_paxos {
         pub sync_idx: u64,
         /// The decided index
         pub decided_idx: u64,
-        /// The accepted index
-        pub accepted_idx: u64,
+        /// The compacted index of the `decided_snapshot`
+        pub compacted_idx: u64,
         /// StopSign to be accepted
         pub stopsign: Option<StopSign>,
     }

--- a/omnipaxos/src/messages.rs
+++ b/omnipaxos/src/messages.rs
@@ -69,12 +69,10 @@ pub mod sequence_paxos {
         pub decided_snapshot: Option<SnapshotType<T>>,
         /// The log suffix.
         pub suffix: Vec<T>,
-        /// The index of the log where the entries from `sync_item` should be applied at or the compacted idx
+        /// The index of the log where the entries from `suffix` should be applied at (also the compacted idx of `decided_snapshot` if it exists)
         pub sync_idx: u64,
         /// The decided index
         pub decided_idx: u64,
-        /// The compacted index of the `decided_snapshot`
-        pub compacted_idx: u64,
         /// StopSign to be accepted
         pub stopsign: Option<StopSign>,
     }

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -413,6 +413,8 @@ where
 pub enum CompactionErr {
     /// Snapshot was called with an index that is not decided yet. Returns the currently decided index.
     UndecidedIndex(u64),
+    /// Snapshot was called with an index which is already trimmed. Returns the currently compacted index.
+    TrimmedIndex(u64),
     /// Trim was called with an index that is not decided by all servers yet. Returns the index decided by ALL servers currently.
     NotAllDecided(u64),
     /// Trim was called at a follower node. Trim must be called by the leader, which is the returned NodeId.

--- a/omnipaxos/src/sequence_paxos/follower.rs
+++ b/omnipaxos/src/sequence_paxos/follower.rs
@@ -37,7 +37,7 @@ where
                         .internal_storage
                         .get_suffix(decided_idx)
                         .expect("storage error while trying to read log suffix");
-                    (Some(delta_snapshot), suffix)
+                    (delta_snapshot, suffix)
                 } else {
                     let suffix = self
                         .internal_storage
@@ -56,7 +56,7 @@ where
                         .internal_storage
                         .get_suffix(decided_idx)
                         .expect("storage error while trying to read log suffix");
-                    (Some(delta_snapshot), suffix)
+                    (delta_snapshot, suffix)
                 } else {
                     let suffix = self
                         .internal_storage
@@ -123,9 +123,9 @@ where
                         SnapshotType::Complete(c) => {
                             self.internal_storage.set_snapshot(accsync.compacted_idx, c)
                         }
-                        SnapshotType::Delta(d) => {
-                            self.internal_storage.merge_snapshot(accsync.compacted_idx, d)
-                        }
+                        SnapshotType::Delta(d) => self
+                            .internal_storage
+                            .merge_snapshot(accsync.compacted_idx, d),
                     };
                     self.internal_storage.rollback_and_panic_if_err(
                         &snapshot_res,

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -217,7 +217,7 @@ where
             .leader_state
             .get_decided_idx(*pid)
             .expect("Received PromiseMetaData but not found in ld");
-        let (delta_snapshot, suffix, sync_idx) = if followers_promise_n == max_promise_n {
+        let (delta_snapshot, suffix, sync_idx) = if (followers_promise_n == max_promise_n) || (*followers_promise_n == self.leader_state.n_leader) {
             // Follower's accepted entries are valid, send any new entries after
             if T::Snapshot::use_snapshots() && *followers_accepted_idx < my_decided_idx {
                 // Note: we snapshot from follower's decided and not follower's accepted because

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -314,10 +314,14 @@ where
         }
     }
 
-    fn send_decide(&mut self, to: NodeId, decided_idx: u64) {
+    pub(crate) fn send_decide(&mut self, to: NodeId, decided_idx: u64, resend: bool) {
+        let seq_num = match resend {
+            true => self.leader_state.get_seq_num(to),
+            false => self.leader_state.next_seq_num(to),
+        };
         let d = Decide {
             n: self.leader_state.n_leader,
-            seq_num: self.leader_state.next_seq_num(to),
+            seq_num,
             decided_idx,
         };
         self.outgoing.push(PaxosMessage {
@@ -532,13 +536,13 @@ where
                                     PaxosMsg::AcceptDecide(a) => {
                                         a.decided_idx = decided_idx;
                                     }
-                                    _ => self.send_decide(pid, decided_idx),
+                                    _ => self.send_decide(pid, decided_idx, false),
                                 }
                             }
-                            _ => self.send_decide(pid, decided_idx),
+                            _ => self.send_decide(pid, decided_idx, false),
                         }
                     } else {
-                        self.send_decide(pid, decided_idx);
+                        self.send_decide(pid, decided_idx, false);
                     }
                 }
             }

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -239,7 +239,7 @@ where
                 (None, sfx, *followers_accepted_idx)
             }
         } else {
-            // Follower's accepted entries are not valid, send everying after follower's decided
+            // Follower's accepted entries are not valid. Synchronize by sending a snapshot from the follower's decided index up to leader's decided index and any suffix.
             if T::Snapshot::use_snapshots() && followers_decided_idx < my_decided_idx {
                 let (delta_snapshot, compacted_idx) = self
                     .internal_storage

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -204,7 +204,7 @@ where
 
     fn send_accsync(&mut self, to: NodeId) {
         let my_decided_idx = self.get_decided_idx();
-        let my_n = self.leader_state.n_leader;
+        let current_n = self.leader_state.n_leader;
         let PromiseMetaData {
             n_accepted: prev_round_max_promise_n,
             accepted_idx: prev_round_max_accepted_idx,
@@ -221,7 +221,7 @@ where
             .get_decided_idx(*pid)
             .expect("Received PromiseMetaData but not found in ld");
         // Follower can have valid accepted entries depending on which leader they were previously following
-        let followers_valid_entries_idx = if *followers_promise_n == my_n {
+        let followers_valid_entries_idx = if *followers_promise_n == current_n {
             *followers_accepted_idx
         } else if *followers_promise_n == *prev_round_max_promise_n {
             *prev_round_max_accepted_idx
@@ -252,7 +252,7 @@ where
             };
         self.leader_state.increment_seq_num_session(to);
         let acc_sync = AcceptSync {
-            n: my_n,
+            n: current_n,
             seq_num: self.leader_state.next_seq_num(to),
             decided_snapshot: delta_snapshot,
             suffix,

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -40,7 +40,7 @@ where
                 decided_idx,
                 accepted_idx,
                 suffix: vec![],
-                stopsign: self.get_stopsign(),
+                stopsign: self.internal_storage.get_stopsign(),
             };
             self.leader_state.set_promise(my_promise, self.pid, true);
             /* initialise longest chosen sequence and update state */
@@ -265,7 +265,8 @@ where
             suffix,
             sync_idx,
             decided_idx: my_decided_idx,
-            stopsign: self.get_stopsign(),
+            accepted_idx: self.internal_storage.get_accepted_idx(),
+            stopsign: self.internal_storage.get_stopsign(),
         };
         let msg = PaxosMessage {
             from: self.pid,
@@ -432,12 +433,13 @@ where
                             ],
                             "storage error while trying to write log entries",
                         );
-                        if let Some(ss) = max_stopsign {
-                            self.accept_stopsign(ss);
-                        } else {
+                        if max_stopsign.is_none() {
                             self.append_pending_proposals();
                             self.adopt_pending_stopsign();
                         }
+                        self.internal_storage
+                            .set_stopsign(max_stopsign)
+                            .expect("storage error while trying to write stopsign");
                     }
                     None => {
                         // no snapshot, only suffix
@@ -455,12 +457,13 @@ where
                             ],
                             "storage error while trying to write log entries",
                         );
-                        if let Some(ss) = max_stopsign {
-                            self.accept_stopsign(ss);
-                        } else {
+                        if max_stopsign.is_none() {
                             self.append_pending_proposals();
                             self.adopt_pending_stopsign();
                         }
+                        self.internal_storage
+                            .set_stopsign(max_stopsign)
+                            .expect("storage error while trying to write stopsign");
                     }
                 }
             }

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -236,7 +236,7 @@ where
                         true => my_decided_idx - 1,
                         false => my_decided_idx,
                     };
-                    (Some(delta_snapshot), suffix, follower_decided_idx, compacted_idx)
+                    (delta_snapshot, suffix, follower_decided_idx, compacted_idx)
                 } else {
                     let sfx = self
                         .internal_storage
@@ -245,7 +245,6 @@ where
                     (None, sfx, *promise_accepted_idx, 0)
                 }
             } else if follower_decided_idx < my_decided_idx && T::Snapshot::use_snapshots() {
-                println!("Followers ballot was outdated");
                 let delta_snapshot = self
                     .internal_storage
                     .create_diff_snapshot(follower_decided_idx)
@@ -258,7 +257,7 @@ where
                     true => my_decided_idx - 1,
                     false => my_decided_idx,
                 };
-                (Some(delta_snapshot), suffix, follower_decided_idx, compacted_idx)
+                (delta_snapshot, suffix, follower_decided_idx, compacted_idx)
             } else {
                 let suffix = self
                     .internal_storage

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -218,11 +218,8 @@ where
                 if *phase == Phase::Accept {
                     if let Some(ss) = self.internal_storage.get_stopsign() {
                         let decided_idx = self.internal_storage.get_decided_idx();
-
                         for follower in self.leader_state.get_promised_followers() {
-                            if !ss.decided(decided_idx)
-                                && !ss.decided(self.leader_state.get_accepted_idx(follower))
-                            {
+                            if !ss.decided(self.leader_state.get_accepted_idx(follower)) {
                                 self.send_accept_stopsign(follower, ss.stopsign.clone(), true);
                             }
                             if ss.decided(decided_idx) {
@@ -231,7 +228,6 @@ where
                         }
                     }
                 }
-
                 // Resend Prepare
                 let unpromised_peers = self.leader_state.get_unpromised_peers();
                 for peer in unpromised_peers {

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -402,6 +402,10 @@ where
         self.internal_storage
             .set_stopsign(Some(ss))
             .expect("storage error while trying to write stopsign");
+        if self.state.0 == Role::Leader {
+            let accepted_idx = self.internal_storage.get_accepted_idx();
+            self.leader_state.set_accepted_idx(self.pid, accepted_idx);
+        }
     }
 
     /// Handles re-establishing a connection to a previously disconnected peer.

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -221,8 +221,7 @@ where
                         for follower in self.leader_state.get_promised_followers() {
                             if self.internal_storage.stopsign_is_decided() {
                                 self.send_decide(follower, decided_idx, true);
-                            }
-                            else if self.leader_state.get_accepted_idx(follower)
+                            } else if self.leader_state.get_accepted_idx(follower)
                                 != self.internal_storage.get_accepted_idx()
                             {
                                 self.send_accept_stopsign(follower, ss.clone(), true);

--- a/omnipaxos/src/storage.rs
+++ b/omnipaxos/src/storage.rs
@@ -632,7 +632,7 @@ where
         self.state_cache.decided_idx
     }
 
-    fn get_log_decided_idx(&self) -> u64 {
+    fn get_decided_idx_without_stopsign(&self) -> u64 {
         match self.stopsign_is_decided() {
             true => self.get_decided_idx() - 1,
             false => self.get_decided_idx(),
@@ -707,7 +707,7 @@ where
     }
 
     fn create_decided_snapshot(&mut self) -> StorageResult<T::Snapshot> {
-        let log_decided_idx = self.get_log_decided_idx();
+        let log_decided_idx = self.get_decided_idx_without_stopsign();
         self.create_snapshot(log_decided_idx)
     }
 
@@ -723,7 +723,7 @@ where
         &mut self,
         from_idx: u64,
     ) -> StorageResult<(Option<SnapshotType<T>>, u64)> {
-        let log_decided_idx = self.get_log_decided_idx();
+        let log_decided_idx = self.get_decided_idx_without_stopsign();
         let compacted_idx = self.get_compacted_idx();
         let snapshot = if from_idx <= compacted_idx {
             // Some entries in range are compacted, snapshot entire decided log
@@ -812,7 +812,7 @@ where
 
     pub(crate) fn try_snapshot(&mut self, snapshot_idx: Option<u64>) -> StorageResult<()> {
         let decided_idx = self.get_decided_idx();
-        let log_decided_idx = self.get_log_decided_idx();
+        let log_decided_idx = self.get_decided_idx_without_stopsign();
         let idx = match snapshot_idx {
             Some(i) => {
                 if i > decided_idx {

--- a/omnipaxos/src/storage.rs
+++ b/omnipaxos/src/storage.rs
@@ -682,10 +682,9 @@ where
 
     pub(crate) fn create_snapshot(&mut self, compact_idx: u64) -> StorageResult<T::Snapshot> {
         let compacted_idx = self.get_compacted_idx();
-        assert!(
-            compact_idx >= compacted_idx,
-            "Can't create snapshot, index {compact_idx} already trimmed"
-        );
+        if compact_idx < compacted_idx {
+            Err(CompactionErr::TrimmedIndex(compacted_idx))?
+        }
         let entries = self.storage.get_entries(0, compact_idx - compacted_idx)?;
         let delta = T::Snapshot::create(entries.as_slice());
         match self.storage.get_snapshot()? {

--- a/omnipaxos/src/storage.rs
+++ b/omnipaxos/src/storage.rs
@@ -422,7 +422,7 @@ where
                     compacted_idx,
                     decided_idx,
                 )?;
-                entries.push(LogEntry::StopSign(ss));
+                entries.push(LogEntry::StopSign(ss, self.stopsign_is_decided()));
                 Ok(Some(entries))
             }
             (IndexEntry::Compacted, IndexEntry::Entry) => {
@@ -453,11 +453,14 @@ where
                     decided_idx,
                 )?;
                 entries.append(&mut e);
-                entries.push(LogEntry::StopSign(ss));
+                entries.push(LogEntry::StopSign(ss, self.stopsign_is_decided()));
                 Ok(Some(entries))
             }
             (IndexEntry::StopSign(ss), IndexEntry::StopSign(_)) => {
-                Ok(Some(vec![LogEntry::StopSign(ss)]))
+                Ok(Some(vec![LogEntry::StopSign(
+                    ss,
+                    self.stopsign_is_decided(),
+                )]))
             }
             e => {
                 unimplemented!("{}", format!("Unexpected read combination: {:?}", e))

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -245,8 +245,9 @@ where
     Trimmed(TrimmedIndex),
     /// The entry has been snapshotted.
     Snapshotted(SnapshottedEntry<T>),
-    /// This Sequence Paxos instance has been stopped for reconfiguration.
-    StopSign(StopSign),
+    /// This Sequence Paxos instance has been stopped for reconfiguration. The accompanying bool
+    /// indicates whether the reconfiguration has been decided or not.
+    StopSign(StopSign, bool),
 }
 
 /// Convenience struct for checking if a certain index exists, is compacted or is a StopSign.

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -16,7 +16,7 @@ pub(crate) struct AcceptedMetaData<T: Entry> {
 #[derive(Debug, Clone, Default)]
 /// Promise without the suffix
 pub(crate) struct PromiseMetaData {
-    pub n: Ballot,
+    pub n_accepted: Ballot,
     pub accepted_idx: u64,
     pub pid: NodeId,
     pub stopsign: Option<StopSign>,
@@ -24,12 +24,13 @@ pub(crate) struct PromiseMetaData {
 
 impl PartialOrd for PromiseMetaData {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let ordering = if self.n == other.n
+        let ordering = if self.n_accepted == other.n_accepted
             && self.accepted_idx == other.accepted_idx
             && self.pid == other.pid
         {
             Ordering::Equal
-        } else if self.n > other.n || (self.n == other.n && self.accepted_idx > other.accepted_idx)
+        } else if self.n_accepted > other.n_accepted
+            || (self.n_accepted == other.n_accepted && self.accepted_idx > other.accepted_idx)
         {
             Ordering::Greater
         } else {
@@ -41,7 +42,9 @@ impl PartialOrd for PromiseMetaData {
 
 impl PartialEq for PromiseMetaData {
     fn eq(&self, other: &Self) -> bool {
-        self.n == other.n && self.accepted_idx == other.accepted_idx && self.pid == other.pid
+        self.n_accepted == other.n_accepted
+            && self.accepted_idx == other.accepted_idx
+            && self.pid == other.pid
     }
 }
 
@@ -125,7 +128,7 @@ where
 
     pub fn set_promise(&mut self, prom: Promise<T>, from: u64, check_max_prom: bool) -> bool {
         let promise_meta = PromiseMetaData {
-            n: prom.n_accepted,
+            n_accepted: prom.n_accepted,
             accepted_idx: prom.accepted_idx,
             pid: from,
             stopsign: prom.stopsign,

--- a/omnipaxos/tests/atomic_storage_test.rs
+++ b/omnipaxos/tests/atomic_storage_test.rs
@@ -17,8 +17,7 @@ use omnipaxos::{
     messages::{
         ballot_leader_election::{BLEMessage, HeartbeatMsg, HeartbeatReply},
         sequence_paxos::{
-            AcceptDecide, AcceptSync, Compaction, PaxosMessage, PaxosMsg, Prepare,
-            Promise,
+            AcceptDecide, AcceptSync, Compaction, PaxosMessage, PaxosMsg, Prepare, Promise,
         },
         Message,
     },

--- a/omnipaxos/tests/atomic_storage_test.rs
+++ b/omnipaxos/tests/atomic_storage_test.rs
@@ -175,7 +175,6 @@ fn setup_follower() -> (
             suffix: vec![],
             sync_idx: 0,
             decided_idx: 0,
-            compacted_idx: 0,
             stopsign: None,
         }),
     });
@@ -229,7 +228,6 @@ fn atomic_storage_acceptsync_test() {
                 suffix: vec![Value(1), Value(2), Value(3)],
                 sync_idx: 0,
                 decided_idx: 1,
-                compacted_idx: 0,
                 stopsign: None,
             }),
         });

--- a/omnipaxos/tests/atomic_storage_test.rs
+++ b/omnipaxos/tests/atomic_storage_test.rs
@@ -17,14 +17,14 @@ use omnipaxos::{
     messages::{
         ballot_leader_election::{BLEMessage, HeartbeatMsg, HeartbeatReply},
         sequence_paxos::{
-            AcceptDecide, AcceptSync, Accepted, Compaction, PaxosMessage, PaxosMsg, Prepare,
+            AcceptDecide, AcceptSync, Compaction, PaxosMessage, PaxosMsg, Prepare,
             Promise,
         },
         Message,
     },
     storage::{Snapshot, SnapshotType, Storage},
     util::{NodeId, SequenceNumber},
-    ClusterConfig, OmniPaxos, OmniPaxosConfig,
+    OmniPaxos, OmniPaxosConfig,
 };
 use omnipaxos_storage::memory_storage::MemoryStorage;
 use serial_test::serial;
@@ -60,7 +60,7 @@ fn basic_setup() -> (
 /// Creates a new OmniPaxos instance with `BrokenStorage` in a `LEADER ACCEPT` state.
 /// Also returns an `Arc<Mutex<_>>` pointer to the underlying `MemoryStorage` and
 /// `BrokenStorageConfig` to enable injecting storage errors.
-fn setup_leader() -> (
+fn _setup_leader() -> (
     Arc<Mutex<MemoryStorage<Value>>>,
     Arc<Mutex<BrokenStorageConfig>>,
     OmniPaxos<Value, StorageType<Value>>,
@@ -176,7 +176,7 @@ fn setup_follower() -> (
             suffix: vec![],
             sync_idx: 0,
             decided_idx: 0,
-            accepted_idx: 0,
+            compacted_idx: 0,
             stopsign: None,
         }),
     });
@@ -230,7 +230,7 @@ fn atomic_storage_acceptsync_test() {
                 suffix: vec![Value(1), Value(2), Value(3)],
                 sync_idx: 0,
                 decided_idx: 1,
-                accepted_idx: 1,
+                compacted_idx: 0,
                 stopsign: None,
             }),
         });
@@ -528,61 +528,3 @@ fn atomic_storage_majority_promises_test() {
         run_single_test(i);
     }
 }
-
-// TODO: Reimplement this test with new StopSign setup
-// #[test]
-// #[serial]
-// fn atomic_storage_majority_accepted_stopsign_test() {
-//     fn run_single_test(fail_after_n_ops: usize) {
-//         let (mem_storage, storage_conf, mut op) = setup_leader();
-//         let new_config = ClusterConfig {
-//             configuration_id: 2,
-//             nodes: vec![1, 2, 3],
-//             flexible_quorum: None,
-//         };
-//         op.reconfigure(new_config, None).unwrap();
-//         op.outgoing_messages();
-//
-//         let old_decided_idx = mem_storage.lock().unwrap().get_decided_idx().unwrap();
-//         let old_stopsign = mem_storage.lock().unwrap().get_stopsign().unwrap().unwrap();
-//         storage_conf
-//             .lock()
-//             .unwrap()
-//             .schedule_failure_in(fail_after_n_ops);
-//
-//         let stopsign_idx = mem_storage
-//             .lock()
-//             .unwrap()
-//             .get_stopsign()
-//             .unwrap()
-//             .unwrap()
-//             .log_idx;
-//         let msg = Message::<Value>::SequencePaxos(PaxosMessage {
-//             from: 2,
-//             to: 1,
-//             msg: PaxosMsg::Accepted(Accepted {
-//                 n: mem_storage.lock().unwrap().get_promise().unwrap().unwrap(),
-//                 accepted_idx: stopsign_idx + 1,
-//             }),
-//         });
-//         let _res = catch_unwind(AssertUnwindSafe(|| op.handle_incoming(msg.clone())));
-//
-//         // check consistency
-//         let s = mem_storage.lock().unwrap();
-//         let new_decided_idx = s.get_decided_idx().unwrap();
-//         let new_stopsign = s.get_stopsign().unwrap().unwrap();
-//         assert!(
-//             !old_stopsign.decided(old_decided_idx),
-//             "sanity check failed: newly proposed stopsign is decided"
-//         );
-//         assert!(
-//             (new_decided_idx == old_decided_idx && !new_stopsign.decided(new_decided_idx))
-//                 || (new_decided_idx > old_decided_idx && new_stopsign.decided(new_decided_idx)),
-//             "decided_idx and decided_stopsign should be updated atomically"
-//         );
-//     }
-//     // run the test with injected failures at different points in time
-//     for i in 1..10 {
-//         run_single_test(i);
-//     }
-// }

--- a/omnipaxos/tests/config/test.toml
+++ b/omnipaxos/tests/config/test.toml
@@ -60,3 +60,6 @@ storage_type = { type = "Persistent" }
 [atomic_storage_test]
 num_nodes = 3
 storage_type = { type = "Broken" }
+
+[sync_test]
+num_nodes = 3

--- a/omnipaxos/tests/config/test.toml
+++ b/omnipaxos/tests/config/test.toml
@@ -40,6 +40,7 @@ storage_type = { type = "Persistent" }
 
 [gc_test]
 wait_timeout_ms = 3000
+
 num_threads = 8
 num_nodes = 3
 num_proposals = 10000

--- a/omnipaxos/tests/consensus_test.rs
+++ b/omnipaxos/tests/consensus_test.rs
@@ -2,7 +2,7 @@ pub mod utils;
 
 use kompact::prelude::{promise, Ask, FutureCollection};
 use omnipaxos::{
-    storage::{Snapshot, StopSign, StopSignEntry, Storage},
+    storage::{Snapshot, StopSign, Storage},
     ClusterConfig, OmniPaxosConfig,
 };
 use serial_test::serial;
@@ -137,7 +137,7 @@ fn read_test() {
         .append_entries(log.clone())
         .expect("Failed to append entries");
     stopped_storage
-        .set_stopsign(StopSignEntry::with(ss.clone(), log_len))
+        .set_stopsign(Some(ss.clone()))
         .expect("Failed to set StopSign");
     stopped_storage
         .set_decided_idx(log_len + 1)
@@ -230,9 +230,7 @@ fn read_entries_test() {
     stopped_storage
         .append_entries(log.clone())
         .expect("Failed to append entries");
-    stopped_storage
-        .set_stopsign(StopSignEntry::with(ss.clone(), log_len))
-        .unwrap();
+    stopped_storage.set_stopsign(Some(ss.clone())).unwrap();
     stopped_storage.set_decided_idx(log_len + 1).unwrap();
 
     let mut stopped_op = op_config.build(stopped_storage).unwrap();

--- a/omnipaxos/tests/reconnect_test.rs
+++ b/omnipaxos/tests/reconnect_test.rs
@@ -9,7 +9,7 @@ use omnipaxos::{
 use serial_test::serial;
 use std::{thread, time::Duration};
 use utils::{
-    verification::{verify_entries, verify_log, verify_stopsign},
+    verification::{verify_log, verify_stopsign},
     TestConfig, TestSystem, Value,
 };
 
@@ -436,31 +436,16 @@ fn reconnect_after_dropped_preparereq_test() {
     };
 }
 
-/// Verifies that a follower that misses an AcceptStopSign message from their leader
-/// eventually receives the missed AcceptStopSign. The test ensures that the follower
-/// never sees a DecideStopSign, and thus can't use it to detect the dropped AcceptStopSign.
+/// Verifies that a follower that misses an AcceptStopSign message and then becomes the leader
+/// correctly syncs the decided stopsign in the sync phase.
 #[test]
 #[serial]
-// TODO: Re-visit once SS changes are finalized
-#[ignore]
-fn reconnect_after_dropped_acceptstopsign_test_old() {
+fn resync_after_dropped_acceptstopsign_test() {
     // Start Kompact system
     let cfg = TestConfig::load("reconnect_test").expect("Test config couldn't be loaded");
     let mut sys = TestSystem::with(cfg);
     sys.start_all_nodes();
 
-    let initial_proposals: Vec<Value> = (0..INITIAL_PROPOSALS)
-        .into_iter()
-        .map(|v| Value(v))
-        .collect();
-    let expected_entries = initial_proposals.clone();
-
-    // Propose some values so that a leader is elected
-    sys.make_proposals(
-        2,
-        initial_proposals,
-        Duration::from_millis(cfg.wait_timeout_ms),
-    );
     let leader_id = sys.get_elected_leader(2, Duration::from_millis(cfg.wait_timeout_ms));
     let leader = sys.nodes.get(&leader_id).unwrap();
     let follower_id = (1..=cfg.num_nodes as u64)
@@ -488,23 +473,18 @@ fn reconnect_after_dropped_acceptstopsign_test_old() {
     leader.on_definition(|comp| {
         comp.set_connection(follower_id, true);
     });
-    // Wait for leader to resend AcceptStopSign
-    thread::sleep(SLEEP_TIMEOUT);
+
+    // Check that follower has become the new leader
+    let new_leader_id = sys.get_elected_leader(1, Duration::from_millis(cfg.wait_timeout_ms));
+    assert!(new_leader_id == follower_id);
 
     // Verify log
     let followers_log: Vec<LogEntry<Value>> = follower.on_definition(|comp| {
         comp.paxos
             .read_decided_suffix(0)
-            .expect("Cannot read decided log entry")
+            .expect("Cannot read log entry")
     });
-    let (followers_entries, followers_stopsign) = followers_log.split_at(followers_log.len() - 1);
-    verify_entries(
-        followers_entries,
-        &expected_entries,
-        0,
-        followers_entries.len() as u64,
-    );
-    verify_stopsign(followers_stopsign, &StopSign::with(next_config, None));
+    verify_stopsign(&followers_log, &StopSign::with(next_config, None));
 
     // Shutdown system
     println!("Passed reconnect_to_leader_test!");
@@ -522,8 +502,6 @@ fn reconnect_after_dropped_acceptstopsign_test_old() {
 /// AcceptStopSign.
 #[test]
 #[serial]
-// TODO: unignore once we can read accepted StopSigns
-#[ignore]
 fn reconnect_after_dropped_acceptstopsign_test() {
     // Start Kompact system
     let cfg = TestConfig::load("reconnect_test").expect("Test config couldn't be loaded");
@@ -582,6 +560,72 @@ fn reconnect_after_dropped_acceptstopsign_test() {
         &followers_log,
         &StopSign::with(next_config, Some(vec![1, 2, 3])),
     );
+
+    // Shutdown system
+    println!("Passed reconnect_to_leader_test!");
+    let kompact_system =
+        std::mem::take(&mut sys.kompact_system).expect("No KompactSystem in memory");
+    match kompact_system.shutdown() {
+        Ok(_) => {}
+        Err(e) => panic!("Error on kompact shutdown: {}", e),
+    };
+}
+
+/// Verifies that a follower that misses DecideStopSign message from their leader
+/// eventually receives the missed DecideStopSign.
+/// TODO: Follower detects sequence break since leader repeated(from too many accepteds) decide
+#[test]
+#[serial]
+fn reconnect_after_dropped_decidestopsign_test() {
+    // Start Kompact system
+    let cfg = TestConfig::load("reconnect_test").expect("Test config couldn't be loaded");
+    let mut sys = TestSystem::with(cfg);
+    sys.start_all_nodes();
+
+    let leader_id = sys.get_elected_leader(1, Duration::from_millis(cfg.wait_timeout_ms));
+    let mut followers = (1..=cfg.num_nodes as u64)
+        .into_iter()
+        .filter(|x| *x != leader_id);
+    let follower_id = followers.next().expect("Couldn't find follower");
+    let leader = sys.nodes.get(&leader_id).unwrap();
+
+    // Disconnect follower from everyone and then decide a StopSign
+    let next_config = ClusterConfig {
+        configuration_id: 2,
+        nodes: vec![1, 2],
+        flexible_quorum: None,
+    };
+    for other_follower in followers.clone() {
+        sys.nodes
+            .get(&other_follower)
+            .unwrap()
+            .on_definition(|comp| {
+                comp.set_connection(follower_id, false);
+            });
+    }
+    leader.on_definition(|comp| {
+        comp.set_connection(follower_id, false);
+        comp.paxos
+            .reconfigure(next_config.clone(), None)
+            .expect("Couldn't reconfigure!")
+    });
+    // Wait for DecideStopSign to be sent and dropped
+    thread::sleep(SLEEP_TIMEOUT);
+
+    // Reconnect leader to follower
+    leader.on_definition(|comp| {
+        comp.set_connection(follower_id, true);
+    });
+    // Wait for leader to resend DecideStopSign
+    thread::sleep(SLEEP_TIMEOUT);
+
+    // Verify log
+    let follower = sys.nodes.get(&follower_id).unwrap();
+    follower.on_definition(|comp| {
+        comp.paxos
+            .is_reconfigured()
+            .expect("Stopsign entry wasn't decided");
+    });
 
     // Shutdown system
     println!("Passed reconnect_to_leader_test!");

--- a/omnipaxos/tests/reconnect_test.rs
+++ b/omnipaxos/tests/reconnect_test.rs
@@ -573,7 +573,6 @@ fn reconnect_after_dropped_acceptstopsign_test() {
 
 /// Verifies that a follower that misses DecideStopSign message from their leader
 /// eventually receives the missed DecideStopSign.
-/// TODO: Follower detects sequence break since leader repeated(from too many accepteds) decide
 #[test]
 #[serial]
 fn reconnect_after_dropped_decidestopsign_test() {

--- a/omnipaxos/tests/recovery_test.rs
+++ b/omnipaxos/tests/recovery_test.rs
@@ -4,7 +4,7 @@ use kompact::prelude::{promise, Ask, FutureCollection, KFuture};
 use omnipaxos::util::LogEntry;
 use serial_test::serial;
 use std::{thread, time::Duration};
-use utils::{verification::verify_log, TestConfig, TestSystem, Value};
+use utils::{verification::verify_log, StorageType, TestConfig, TestSystem, Value};
 
 const SLEEP_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -251,6 +251,8 @@ pub fn kill_and_recover_node(sys: &mut TestSystem, cfg: &TestConfig, pid: u64) {
     thread::sleep(SLEEP_TIMEOUT);
 
     let storage_path = sys.temp_dir_path.clone();
-    sys.create_node(pid, cfg, cfg.storage_type, &storage_path);
+    let storage: StorageType<Value> =
+        StorageType::with(cfg.storage_type, &format!("{storage_path}{pid}"));
+    sys.create_node(pid, cfg, storage);
     sys.start_node(pid);
 }

--- a/omnipaxos/tests/sync_test.rs
+++ b/omnipaxos/tests/sync_test.rs
@@ -20,6 +20,9 @@ struct SyncTest {
     followers_compacted_idx: Option<u64>,
 }
 
+/// Tests that a leader whose log consists of everything a log can be made up of (snapshot, decided entries,
+/// undecided entries, stopsign), correctly syncs a follower who is missing decided entries and
+/// has invalid undecided entries.
 #[test]
 #[serial]
 fn sync_full_test() {
@@ -53,6 +56,8 @@ fn sync_full_test() {
     sync_test(test);
 }
 
+/// Tests that a leader, who has a decided stopsign, correctly syncs a follower who is missing
+/// decided entries and has invalid undecided entries.
 #[test]
 #[serial]
 fn sync_decided_ss_test() {
@@ -78,6 +83,7 @@ fn sync_decided_ss_test() {
     sync_test(test);
 }
 
+/// Tests that a leader whose log consists of only a stopsign correctly syncs the follower.
 #[test]
 #[serial]
 fn sync_only_stopsign_test() {
@@ -99,6 +105,8 @@ fn sync_only_stopsign_test() {
     sync_test(test);
 }
 
+/// Tests that the leader syncs the follower using a decided snapshot which the follower correctly
+/// merges onto their empty log.
 #[test]
 #[serial]
 fn sync_only_snapshot_test() {
@@ -120,6 +128,8 @@ fn sync_only_snapshot_test() {
     sync_test(test);
 }
 
+/// Tests that the leader syncs the follower using a decided snapshot which correctly merges onto
+/// the partly-snapshotted decided entries of the follower.
 #[test]
 #[serial]
 fn sync_follower_snapshot_test() {

--- a/omnipaxos/tests/sync_test.rs
+++ b/omnipaxos/tests/sync_test.rs
@@ -139,7 +139,10 @@ fn sync_basic_test() {
     leaders_ss.next_config.nodes = vec![1, 2, 3];
 
     // Define follower's log
-    let followers_log = [1, 2, 3, 6, 7].into_iter().map(|x| Value(x)).collect();
+    let followers_log = [1, 2, 3, 6, 7, 8, 9, 10]
+        .into_iter()
+        .map(|x| Value(x))
+        .collect();
     let followers_dec_idx = 3;
     // fake ballot so that followers promise is seen as out of date
     let followers_accepted_round = Ballot::with(4, 0, 0, 0);

--- a/omnipaxos/tests/sync_test.rs
+++ b/omnipaxos/tests/sync_test.rs
@@ -1,0 +1,244 @@
+pub mod utils;
+
+use omnipaxos::{
+    storage::{Snapshot, StopSign, Storage},
+    ClusterConfig,
+};
+use omnipaxos_storage::memory_storage::MemoryStorage;
+use serial_test::serial;
+use std::{thread, time::Duration};
+use utils::{
+    verification::{verify_log, verify_stopsign},
+    LatestValue, StorageType, TestConfig, TestSystem, Value,
+};
+
+#[derive(Default)]
+struct SyncTest {
+    leaders_snapshot: Option<LatestValue>,
+    leaders_snapshotted_entries: Option<Vec<Value>>,
+    leaders_log: Vec<Value>,
+    leaders_ss: Option<StopSign>,
+    leaders_dec_idx: u64,
+    followers_snapshot: Option<LatestValue>,
+    followers_snapshotted_entries: Option<Vec<Value>>,
+    followers_log: Vec<Value>,
+    followers_ss: Option<StopSign>,
+    followers_dec_idx: u64,
+    followers_ballot_is_outdated: bool,
+}
+
+fn sync_test(sync_test: SyncTest) {
+    // Set up leader's memory
+    let mut leaders_memory = MemoryStorage::default();
+    if let Some(entries) = &sync_test.leaders_snapshotted_entries {
+        leaders_memory
+            .set_snapshot(sync_test.leaders_snapshot)
+            .unwrap();
+        leaders_memory
+            .set_compacted_idx(entries.len() as u64)
+            .unwrap();
+    }
+    leaders_memory
+        .append_entries(sync_test.leaders_log.clone())
+        .unwrap();
+    leaders_memory
+        .set_stopsign(sync_test.leaders_ss.clone())
+        .unwrap();
+    leaders_memory
+        .set_decided_idx(sync_test.leaders_dec_idx)
+        .unwrap();
+
+    // Set up follower's memory
+    let mut followers_memory = MemoryStorage::default();
+    if let Some(entries) = &sync_test.followers_snapshotted_entries {
+        followers_memory
+            .set_snapshot(sync_test.followers_snapshot)
+            .unwrap();
+        followers_memory
+            .set_compacted_idx(entries.len() as u64)
+            .unwrap();
+    }
+    followers_memory
+        .append_entries(sync_test.followers_log.clone())
+        .unwrap();
+    followers_memory
+        .set_stopsign(sync_test.followers_ss.clone())
+        .unwrap();
+    followers_memory
+        .set_decided_idx(sync_test.followers_dec_idx)
+        .unwrap();
+
+    // Start a Kompact system with no nodes
+    let cfg = TestConfig::load("sync_test").expect("Test config couldn't be loaded");
+    let mut sys = TestSystem::with(cfg);
+    sys.start_all_nodes();
+    for node_id in 1..=cfg.num_nodes as u64 {
+        sys.kill_node(node_id);
+    }
+
+    // Re-create nodes with initial memory
+    sys.create_node(1, &cfg, StorageType::with_memory(followers_memory));
+    sys.create_node(2, &cfg, StorageType::with_memory(leaders_memory.clone()));
+    sys.create_node(3, &cfg, StorageType::with_memory(leaders_memory));
+    sys.start_node(2);
+    sys.start_node(3);
+
+    // Force a leader change to increase ballot number and make followers ballot outdated
+    if sync_test.followers_ballot_is_outdated {
+        let leader_id = sys.get_elected_leader(2, Duration::from_millis(cfg.wait_timeout_ms));
+        let leader = sys.nodes.get(&leader_id).unwrap();
+        leader.on_definition(|comp| {
+            comp.paxos.election_timeout();
+            comp.paxos.election_timeout();
+        });
+        sys.get_next_leader(2, Duration::from_millis(cfg.wait_timeout_ms));
+    }
+
+    // Wait for follower to finish syncing
+    sys.start_node(1);
+    thread::sleep(Duration::from_millis(100));
+
+    // Verify log
+    let follower = sys.nodes.get(&1).unwrap();
+    let mut followers_log = follower.on_definition(|comp| {
+        comp.paxos
+            .read_decided_suffix(0)
+            .expect("Cannot read decided log entry")
+    });
+    if let Some(ss) = &sync_test.leaders_ss {
+        let followers_ss = followers_log.pop().expect("Follower had no entries");
+        verify_stopsign(&[followers_ss], ss);
+    }
+
+    let leaders_log = match sync_test.leaders_snapshotted_entries {
+        Some(entries) => [entries, sync_test.leaders_log].concat(),
+        None => sync_test.leaders_log,
+    };
+    verify_log(followers_log, leaders_log);
+}
+
+#[test]
+#[serial]
+fn sync_basic_test() {
+    // Define leader's log
+    let snapshotted_log: Vec<Value> = [1, 2].into_iter().map(|x| Value(x)).collect();
+    let leaders_snapshot = LatestValue::create(&snapshotted_log);
+    let leaders_log = [3, 4, 5, 10, 11, 12]
+        .into_iter()
+        .map(|x| Value(x))
+        .collect();
+    let leaders_dec_idx = 5;
+    let mut leaders_ss = StopSign::with(ClusterConfig::default(), None);
+    leaders_ss.next_config.configuration_id = 2;
+    leaders_ss.next_config.nodes = vec![1, 2, 3];
+
+    // Define follower's log
+    let followers_log = [1, 2, 3, 6, 7].into_iter().map(|x| Value(x)).collect();
+    let followers_dec_idx = 3;
+
+    let test = SyncTest {
+        leaders_snapshot: Some(leaders_snapshot),
+        leaders_snapshotted_entries: Some(snapshotted_log),
+        leaders_log,
+        leaders_ss: Some(leaders_ss),
+        leaders_dec_idx,
+        followers_log,
+        followers_dec_idx,
+        followers_ballot_is_outdated: true,
+        ..Default::default()
+    };
+    sync_test(test);
+}
+
+#[test]
+#[serial]
+fn sync_decided_stopsign_test() {
+    // Define leader's log
+    let leaders_log = [1, 2, 3, 4, 5].into_iter().map(|x| Value(x)).collect();
+    let leaders_dec_idx = 6;
+    let mut leaders_ss = StopSign::with(ClusterConfig::default(), None);
+    leaders_ss.next_config.configuration_id = 2;
+    leaders_ss.next_config.nodes = vec![1, 2, 3];
+
+    // Define follower's log
+    let followers_log = [1, 2, 3, 6, 7].into_iter().map(|x| Value(x)).collect();
+    let followers_dec_idx = 3;
+
+    let test = SyncTest {
+        leaders_log,
+        leaders_ss: Some(leaders_ss),
+        leaders_dec_idx,
+        followers_log,
+        followers_dec_idx,
+        followers_ballot_is_outdated: true,
+        ..Default::default()
+    };
+    sync_test(test);
+}
+
+#[test]
+#[serial]
+fn sync_only_stopsign_test() {
+    // Define leader's log
+    let leaders_dec_idx = 1;
+    let mut leaders_ss = StopSign::with(ClusterConfig::default(), None);
+    leaders_ss.next_config.configuration_id = 2;
+    leaders_ss.next_config.nodes = vec![1, 2, 3];
+
+    // Define follower's log
+    let followers_dec_idx = 0;
+
+    let test = SyncTest {
+        leaders_ss: Some(leaders_ss),
+        leaders_dec_idx,
+        followers_dec_idx,
+        ..Default::default()
+    };
+    sync_test(test);
+}
+
+#[test]
+#[serial]
+fn sync_only_snapshot_test() {
+    // Define leader's log
+    let snapshotted_log: Vec<Value> = [1, 2, 3].into_iter().map(|x| Value(x)).collect();
+    let leaders_snapshot = LatestValue::create(&snapshotted_log);
+    let leaders_dec_idx = 3;
+
+    // Define follower's log
+    let followers_dec_idx = 0;
+
+    let test = SyncTest {
+        leaders_snapshot: Some(leaders_snapshot),
+        leaders_snapshotted_entries: Some(snapshotted_log),
+        leaders_dec_idx,
+        followers_dec_idx,
+        ..Default::default()
+    };
+    sync_test(test);
+}
+
+#[test]
+#[serial]
+fn sync_follower_snapshot_test() {
+    // Define leader's log
+    let leaders_log = [1, 2, 3, 4, 5].into_iter().map(|x| Value(x)).collect();
+    let leaders_dec_idx = 5;
+
+    // Define follower's log
+    let snapshotted_log: Vec<Value> = [1, 2, 3].into_iter().map(|x| Value(x)).collect();
+    let followers_snapshot = LatestValue::create(&snapshotted_log);
+    let followers_log = [4].into_iter().map(|x| Value(x)).collect();
+    let followers_dec_idx = 4;
+
+    let test = SyncTest {
+        leaders_log,
+        leaders_dec_idx,
+        followers_snapshot: Some(followers_snapshot),
+        followers_snapshotted_entries: Some(snapshotted_log),
+        followers_log,
+        followers_dec_idx,
+        ..Default::default()
+    };
+    sync_test(test);
+}

--- a/omnipaxos/tests/utils.rs
+++ b/omnipaxos/tests/utils.rs
@@ -818,7 +818,7 @@ pub mod omnireplica {
                                     .reply(s.snapshot.value)
                                     .expect("Failed to reply promise!");
                             }
-                            LogEntry::StopSign(ss) => self
+                            LogEntry::StopSign(ss, _is_decided) => self
                                 .decided_futures
                                 .pop()
                                 .unwrap()
@@ -984,7 +984,7 @@ pub mod verification {
             read_entries
         );
         match read_entries.first().unwrap() {
-            LogEntry::StopSign(ss) => {
+            LogEntry::StopSign(ss, _is_decided) => {
                 assert_eq!(ss, exp_stopsign);
             }
             e => {

--- a/omnipaxos/tests/utils.rs
+++ b/omnipaxos/tests/utils.rs
@@ -326,7 +326,7 @@ where
         }
     }
 
-    fn set_stopsign(&mut self, s: omnipaxos::storage::StopSignEntry) -> StorageResult<()> {
+    fn set_stopsign(&mut self, s: Option<omnipaxos::storage::StopSign>) -> StorageResult<()> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.set_stopsign(s),
             StorageType::Memory(mem_s) => mem_s.set_stopsign(s),
@@ -337,7 +337,7 @@ where
         }
     }
 
-    fn get_stopsign(&self) -> StorageResult<Option<omnipaxos::storage::StopSignEntry>> {
+    fn get_stopsign(&self) -> StorageResult<Option<omnipaxos::storage::StopSign>> {
         match self {
             StorageType::Persistent(persist_s) => persist_s.get_stopsign(),
             StorageType::Memory(mem_s) => mem_s.get_stopsign(),

--- a/omnipaxos_storage/src/memory_storage.rs
+++ b/omnipaxos_storage/src/memory_storage.rs
@@ -1,6 +1,6 @@
 use omnipaxos::{
     ballot_leader_election::Ballot,
-    storage::{Entry, StopSignEntry, Storage, StorageResult},
+    storage::{Entry, StopSign, Storage, StorageResult},
 };
 /// An in-memory storage implementation for SequencePaxos.
 #[derive(Clone)]
@@ -21,7 +21,7 @@ where
     /// Stored snapshot
     snapshot: Option<T::Snapshot>,
     /// Stored StopSign
-    stopsign: Option<StopSignEntry>,
+    stopsign: Option<StopSign>,
 }
 
 impl<T> Storage<T> for MemoryStorage<T>
@@ -90,12 +90,12 @@ where
         Ok(Some(self.n_prom))
     }
 
-    fn set_stopsign(&mut self, s: StopSignEntry) -> StorageResult<()> {
-        self.stopsign = Some(s);
+    fn set_stopsign(&mut self, s: Option<StopSign>) -> StorageResult<()> {
+        self.stopsign = s;
         Ok(())
     }
 
-    fn get_stopsign(&self) -> StorageResult<Option<StopSignEntry>> {
+    fn get_stopsign(&self) -> StorageResult<Option<StopSign>> {
         Ok(self.stopsign.clone())
     }
 

--- a/omnipaxos_storage/src/persistent_storage.rs
+++ b/omnipaxos_storage/src/persistent_storage.rs
@@ -7,7 +7,7 @@ use commitlog::{
 };
 use omnipaxos::{
     ballot_leader_election::Ballot,
-    storage::{Entry, StopSignEntry, Storage, StorageResult},
+    storage::{Entry, StopSign, Storage, StorageResult},
 };
 use serde::{Deserialize, Serialize};
 use std::{iter::FromIterator, marker::PhantomData};
@@ -391,7 +391,7 @@ where
         Ok(())
     }
 
-    fn get_stopsign(&self) -> StorageResult<Option<StopSignEntry>> {
+    fn get_stopsign(&self) -> StorageResult<Option<StopSign>> {
         #[cfg(feature = "rocksdb")]
         {
             let stopsign = self.rocksdb.get(STOPSIGN)?;
@@ -410,7 +410,7 @@ where
         }
     }
 
-    fn set_stopsign(&mut self, s: StopSignEntry) -> StorageResult<()> {
+    fn set_stopsign(&mut self, s: Option<StopSign>) -> StorageResult<()> {
         let stopsign = bincode::serialize(&s)?;
         #[cfg(feature = "rocksdb")]
         {


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [ ] You updated the OmniPaxos book (if applicable)

## Issues

Fix #68  by resending the decides of StopSigns.

## Breaking Changes
 - The trait function `Storage::set_stopsign(&mut self, s: StopSign) -> StorageResult<()>`'s signature changes to `Storage::set_stopsign(&mut self, s: Option<StopSign>) -> StorageResult<()>`.

## Other Changes
 - Fixed AcceptSync bugs by changing how Stopsign's and Snapshots are created.
 - Accounts for a bug in CommitLog when appending an empty set of entries.