### PR TITLE
Release of v.0.2.0

### DIFF
--- a/examples/kv_store/Cargo.toml
+++ b/examples/kv_store/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-omnipaxos = { version = "0.1.0", features = ["macros"] }
-omnipaxos_storage = { version = "0.1.0" }
+omnipaxos = { path = "../../omnipaxos", features = ["macros"] }
+omnipaxos_storage = { path = "../../omnipaxos_storage"}
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/examples/kv_store/src/server.rs
+++ b/examples/kv_store/src/server.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::{
-    util::{ELECTION_TIMEOUT, OUTGOING_MESSAGE_PERIOD},
+    util::{OUTGOING_MESSAGE_PERIOD, TICK_PERIOD},
     OmniPaxosKV,
 };
 use tokio::{sync::mpsc, time};
@@ -32,12 +32,12 @@ impl OmniPaxosServer {
 
     pub(crate) async fn run(&mut self) {
         let mut outgoing_interval = time::interval(OUTGOING_MESSAGE_PERIOD);
-        let mut election_interval = time::interval(ELECTION_TIMEOUT);
+        let mut tick_interval = time::interval(TICK_PERIOD);
         loop {
             tokio::select! {
                 biased;
 
-                _ = election_interval.tick() => { self.omni_paxos.lock().unwrap().election_timeout(); },
+                _ = tick_interval.tick() => { self.omni_paxos.lock().unwrap().tick(); },
                 _ = outgoing_interval.tick() => { self.send_outgoing_msgs().await; },
                 Some(in_msg) = self.incoming.recv() => { self.omni_paxos.lock().unwrap().handle_incoming(in_msg); },
                 else => { }

--- a/examples/kv_store/src/util.rs
+++ b/examples/kv_store/src/util.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
 pub const BUFFER_SIZE: usize = 10000;
-pub const ELECTION_TIMEOUT: Duration = Duration::from_millis(100);
+pub const ELECTION_TICK_TIMEOUT: u64 = 5;
+pub const TICK_PERIOD: Duration = Duration::from_millis(10);
 pub const OUTGOING_MESSAGE_PERIOD: Duration = Duration::from_millis(1);
 
 pub const WAIT_LEADER_TIMEOUT: Duration = Duration::from_millis(500);

--- a/omnipaxos/Cargo.toml
+++ b/omnipaxos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnipaxos"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Harald Ng <hng@kth.se>"]
 edition = "2021"
 description = "A distributed log library written in Rust"
@@ -19,7 +19,7 @@ slog-term = { version = "2.9.0", optional = true }
 slog-async = { version = "2.7.0", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 toml = { version = "0.7.3", optional = true }
-omnipaxos_macros = { version = "0.1.1", optional = true }
+omnipaxos_macros = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 kompact = { git = "https://github.com/kompics/kompact", rev = "94956af", features = ["silent_logging"] }

--- a/omnipaxos_macros/Cargo.toml
+++ b/omnipaxos_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnipaxos_macros"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Harald Ng <hng@kth.se>"]
 edition = "2021"
 description = "Macros for OmniPaxos."

--- a/omnipaxos_storage/Cargo.toml
+++ b/omnipaxos_storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "omnipaxos_storage"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Harald Ng <hng@kth.se>"]
 edition = "2021"
 description = "Storage implementations for OmniPaxos."
@@ -14,7 +14,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-omnipaxos = { version = "0.1.0", path = "../omnipaxos", features = ["serde"] }
+omnipaxos = { version = "0.2.0", path = "../omnipaxos", features = ["serde"] }
 rocksdb = { version = "0.18.0", optional = true }
 sled = { version = "0.34.7", optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [ ] You reference which issue is being closed in the PR text (if applicable)
- [ ] You updated the OmniPaxos book (if applicable)

## Other Changes
Changes for publishing new version 0.2.0 on crates. This includes updating the version number in the cargo files of `omnipaxos`, `omnipaxos_storage`, and `omnipaxos_macros` and updating the `examples` to use the new API.
