### PR TITLE
AccSync sync_idx fix

### DIFF
--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -224,7 +224,7 @@ where
         let followers_valid_entries_idx = if *followers_promise_n == current_n {
             *followers_accepted_idx
         } else if *followers_promise_n == *prev_round_max_promise_n {
-            *prev_round_max_accepted_idx
+            *prev_round_max_accepted_idx.min(followers_accepted_idx)
         } else {
             followers_decided_idx
         };


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Other Changes
 - Bug in how we calculated followers_valid_entries when the follower had less entries than the max_accepted_idx from the promises.