### PR TITLE
Flush batched entries timer

### DIFF
--- a/omnipaxos/src/sequence_paxos/follower.rs
+++ b/omnipaxos/src/sequence_paxos/follower.rs
@@ -268,4 +268,12 @@ where
             });
         }
     }
+
+    pub(crate) fn flush_batch_follower(&mut self) {
+        let accepted_idx = self.internal_storage.get_accepted_idx();
+        let new_accepted_idx = self.internal_storage.flush_batch().expect(WRITE_ERROR_MSG);
+        if new_accepted_idx > accepted_idx {
+            self.reply_accepted(self.get_promise(), new_accepted_idx);
+        }
+    }
 }

--- a/omnipaxos/src/sequence_paxos/leader.rs
+++ b/omnipaxos/src/sequence_paxos/leader.rs
@@ -397,4 +397,16 @@ where
             Phase::None => (),
         }
     }
+
+    pub(crate) fn flush_batch_leader(&mut self) {
+        let accepted_metadata = self
+            .internal_storage
+            .flush_batch_and_get_entries()
+            .expect(WRITE_ERROR_MSG);
+        if let Some(metadata) = accepted_metadata {
+            self.leader_state
+                .set_accepted_idx(self.pid, metadata.accepted_idx);
+            self.send_acceptdecide(metadata);
+        }
+    }
 }

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -237,6 +237,14 @@ where
         }
     }
 
+    /// Flushes any batched log entries and sends their corresponding Accept or Accepted messages.
+    pub(crate) fn flush_batch_timeout(&mut self) {
+        match self.state.0 {
+            Role::Leader => self.flush_batch_leader(),
+            Role::Follower => self.flush_batch_follower(),
+        }
+    }
+
     /// Returns the outgoing messages from this replica. The messages should then be sent via the network implementation.
     pub(crate) fn get_outgoing_msgs(&mut self) -> Vec<PaxosMessage<T>> {
         let mut outgoing = Vec::with_capacity(self.buffer_size);

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -239,9 +239,10 @@ where
 
     /// Flushes any batched log entries and sends their corresponding Accept or Accepted messages.
     pub(crate) fn flush_batch_timeout(&mut self) {
-        match self.state.0 {
-            Role::Leader => self.flush_batch_leader(),
-            Role::Follower => self.flush_batch_follower(),
+        match self.state {
+            (Role::Leader, Phase::Accept) => self.flush_batch_leader(),
+            (Role::Follower, Phase::Accept) => self.flush_batch_follower(),
+            _ => (),
         }
     }
 

--- a/omnipaxos/src/storage/internal_storage.rs
+++ b/omnipaxos/src/storage/internal_storage.rs
@@ -288,6 +288,17 @@ where
         self.append_entries_without_batching(flushed_entries)
     }
 
+    pub(crate) fn flush_batch_and_get_entries(
+        &mut self,
+    ) -> StorageResult<Option<AcceptedMetaData<T>>> {
+        let flushed_entries = if !self.state_cache.batched_entries.is_empty() {
+            Some(self.state_cache.take_batched_entries())
+        } else {
+            None
+        };
+        self.flush_if_full_batch(flushed_entries)
+    }
+
     // Append entries without batching, return the accepted index
     pub(crate) fn append_entries_without_batching(
         &mut self,

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -337,7 +337,8 @@ pub(crate) mod defaults {
     pub(crate) const BUFFER_SIZE: usize = 100000;
     pub(crate) const BLE_BUFFER_SIZE: usize = 100;
     pub(crate) const ELECTION_TIMEOUT: u64 = 10;
-    pub(crate) const RESEND_MESSAGE_TIMEOUT: u64 = 100;
+    pub(crate) const RESEND_MESSAGE_TIMEOUT: u64 = 1000;
+    pub(crate) const FLUSH_BATCH_TIMEOUT: u64 = 2000;
 }
 
 #[allow(missing_docs)]

--- a/omnipaxos/tests/config/node1.toml
+++ b/omnipaxos/tests/config/node1.toml
@@ -10,6 +10,8 @@ pid = 1
 election_tick_timeout = 10
 # If `tick()` is called every 10ms then dropped messages will be resent every 1000ms
 resend_message_tick_timeout = 100
+# If `tick()` is called every 10ms then batched entries will be flushed every 2000ms
+flush_batch_tick_timeout = 200
 buffer_size = 10000
 batch_size = 2
 logger_file_path = "logs/paxos_1.log"

--- a/omnipaxos/tests/config_test.rs
+++ b/omnipaxos/tests/config_test.rs
@@ -27,6 +27,7 @@ fn config_all_fields_test() {
             assert_eq!(config.server_config.pid, 1);
             assert_eq!(config.server_config.election_tick_timeout, 10);
             assert_eq!(config.server_config.resend_message_tick_timeout, 100);
+            assert_eq!(config.server_config.flush_batch_tick_timeout, 200);
             assert_eq!(config.server_config.buffer_size, 10000);
             assert_eq!(config.server_config.batch_size, 2);
             #[cfg(feature = "logging")]

--- a/omnipaxos/tests/utils.rs
+++ b/omnipaxos/tests/utils.rs
@@ -82,6 +82,9 @@ pub struct TestConfig {
     #[serde(rename(deserialize = "resend_message_timeout_ms"))]
     #[serde(deserialize_with = "deserialize_duration_millis")]
     pub resend_message_timeout: Duration,
+    #[serde(rename(deserialize = "flush_batch_timeout_ms"))]
+    #[serde(deserialize_with = "deserialize_duration_millis")]
+    pub flush_batch_timeout: Duration,
     pub storage_type: StorageTypeSelector,
     pub num_proposals: u64,
     pub num_elections: u64,
@@ -119,8 +122,10 @@ impl TestConfig {
         let server_config = ServerConfig {
             pid,
             election_tick_timeout: 1,
-            // Make tick timeouts reletive to election timeout
+            // Make tick timeouts relative to election timeout
             resend_message_tick_timeout: self.resend_message_timeout.as_millis() as u64
+                / self.election_timeout.as_millis() as u64,
+            flush_batch_tick_timeout: self.flush_batch_timeout.as_millis() as u64
                 / self.election_timeout.as_millis() as u64,
             batch_size: self.batch_size,
             ..Default::default()
@@ -140,6 +145,7 @@ impl Default for TestConfig {
             wait_timeout: Duration::from_millis(5000),
             election_timeout: Duration::from_millis(200),
             resend_message_timeout: Duration::from_millis(500),
+            flush_batch_timeout: Duration::from_millis(2000),
             storage_type: StorageTypeSelector::Memory,
             num_proposals: 100,
             num_elections: 0,


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Issues

Fix #127. `Omnipaxos::tick()` now also flushes batched log entries every `flush_batch_tick_timeout` ticks. This stops entries from being stuck in the batch buffer when there are no incoming proposals.

## Breaking Changes
 - Adds new field `flush_batch_tick_timeout` to `ServerConfig`.