### PR TITLE
expose API for accepted phase

### DIFF
--- a/examples/kv_store/src/main.rs
+++ b/examples/kv_store/src/main.rs
@@ -85,7 +85,8 @@ fn main() {
         .lock()
         .unwrap()
         .get_current_leader()
-        .expect("Failed to get leader");
+        .expect("Failed to get leader")
+        .0;
     println!("Elected leader: {}", leader);
 
     let follower = SERVERS.iter().find(|&&p| p != leader).unwrap();
@@ -137,7 +138,8 @@ fn main() {
         .lock()
         .unwrap()
         .get_current_leader()
-        .expect("Failed to get leader");
+        .expect("Failed to get leader")
+        .0;
     println!("Elected new leader: {}", leader);
     let kv3 = KeyValue {
         key: "b".to_string(),

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -421,7 +421,7 @@ where
 
         ui::OmniPaxosStates {
             current_ballot: self.ble.get_current_ballot(),
-            current_leader: self.get_current_leader(),
+            current_leader: self.get_current_leader().map(|(leader, _)| leader),
             decided_idx: self.get_decided_idx(),
             heartbeats: self.ble.get_ballots(),
             cluster_state,

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -2,7 +2,7 @@ use crate::{
     ballot_leader_election::{Ballot, BallotLeaderElection},
     errors::{valid_config, ConfigError},
     messages::Message,
-    sequence_paxos::SequencePaxos,
+    sequence_paxos::{Phase, SequencePaxos},
     storage::{Entry, StopSign, Storage},
     util::{
         defaults::{BUFFER_SIZE, ELECTION_TIMEOUT, FLUSH_BATCH_TIMEOUT, RESEND_MESSAGE_TIMEOUT},
@@ -269,13 +269,19 @@ where
         self.seq_paxos.get_compacted_idx()
     }
 
-    /// Returns the id of the current leader.
-    pub fn get_current_leader(&self) -> Option<NodeId> {
+    /// Returns the ID of the current leader and whether the node's `Phase` is `Phase::Accepted`.
+    ///
+    /// If the node's phase is `Phase::Accepted`, this implies that the returned leader is also
+    /// in the accepted phase. However, a `Phase::Prepare` or a `false` response does not
+    /// necessarily imply that the leader is not in the accepted phase; it only reflects the current
+    /// phase of this node.
+    pub fn get_current_leader(&self) -> Option<(NodeId, bool)> {
         let promised_pid = self.seq_paxos.get_promise().pid;
         if promised_pid == 0 {
             None
         } else {
-            Some(promised_pid)
+            let is_accepted = self.seq_paxos.get_state().1 == Phase::Accept;
+            Some((promised_pid, is_accepted))
         }
     }
 

--- a/omnipaxos/tests/atomic_storage_test.rs
+++ b/omnipaxos/tests/atomic_storage_test.rs
@@ -132,7 +132,7 @@ fn _setup_leader() -> (
     });
     op.handle_incoming(setup_msg);
     assert!(
-        op.get_current_leader().expect("should have leader") == 1,
+        op.get_current_leader().expect("should have leader").0 == 1,
         "should be leader"
     );
     (mem_storage, storage_conf, op)
@@ -193,7 +193,7 @@ fn setup_follower() -> (
     op.handle_incoming(setup_msg);
     op.outgoing_messages();
     assert!(
-        op.get_current_leader().expect("should have leader") == 2,
+        op.get_current_leader().expect("should have leader").0 == 2,
         "node 2 should be leader"
     );
     (mem_storage, storage_conf, op)
@@ -569,7 +569,7 @@ fn atomic_storage_majority_promises_test() {
         let new_snapshot = s.get_snapshot().unwrap();
         let new_accepted_round = s.get_accepted_round().unwrap();
         assert!(
-            op.get_current_leader().expect("should have leader") == 1,
+            op.get_current_leader().expect("should have leader").0 == 1,
             "should be leader"
         );
         assert!(

--- a/omnipaxos/tests/utils.rs
+++ b/omnipaxos/tests/utils.rs
@@ -636,7 +636,8 @@ impl TestSystem {
     /// wait until a leader is elected in the allocated time.
     pub fn get_elected_leader(&self, node_id: NodeId, wait_timeout: Duration) -> NodeId {
         let node = self.nodes.get(&node_id).expect("No BLE component found");
-        let leader_pid = node.on_definition(|x| x.paxos.get_current_leader());
+        let leader_pid =
+            node.on_definition(|x| x.paxos.get_current_leader().map(|(leader, _)| leader));
         leader_pid.unwrap_or_else(|| self.get_next_leader(node_id, wait_timeout))
     }
 


### PR DESCRIPTION
Added a method to expose `Phase` of an omnipaxos node. 
One usecase for us is to be able to recognise that elected leader is now ready for routing requests.


> [] You ran the local CI checker with `./check.sh` with no errors 

a `omnipaxos/tests/ble_test` seems broken in master?




