### PR TITLE
Support for single peer cluster

### DIFF
--- a/examples/dashboard/src/util.rs
+++ b/examples/dashboard/src/util.rs
@@ -51,7 +51,8 @@ pub(crate) fn parse_arguments() -> Result<(u64, u64, Duration, u64), String> {
             }
             "duration" => {
                 i += 1;
-                duration_in_seconds = args[i].parse().expect("Invalid duration."); // Set the default duration to 10
+                duration_in_seconds = args[i].parse().expect("Invalid duration.");
+                // Set the default duration to 10
             }
             "crash" => {
                 i += 1;

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -103,7 +103,6 @@ impl ClusterConfig {
     /// Checks that all the fields of the cluster config are valid.
     pub fn validate(&self) -> Result<(), ConfigError> {
         let num_nodes = self.nodes.len();
-        valid_config!(num_nodes > 1, "Need more than 1 node");
         valid_config!(self.configuration_id != 0, "Configuration ID cannot be 0");
         if let Some(FlexibleQuorum {
             read_quorum_size,
@@ -113,14 +112,6 @@ impl ClusterConfig {
             valid_config!(
                 read_quorum_size + write_quorum_size > num_nodes,
                 "The quorums must overlap i.e., the sum of their sizes must exceed the # of nodes"
-            );
-            valid_config!(
-                read_quorum_size >= 2 && read_quorum_size <= num_nodes,
-                "Read quorum must be in range 2 to # of nodes in the cluster"
-            );
-            valid_config!(
-                write_quorum_size >= 2 && write_quorum_size <= num_nodes,
-                "Write quorum must be in range 2 to # of nodes in the cluster"
             );
             valid_config!(
                 read_quorum_size >= write_quorum_size,

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -55,7 +55,7 @@ where
         let peers = config.peers;
         let num_nodes = &peers.len() + 1;
         let quorum = Quorum::with(config.flexible_quorum, num_nodes);
-        let max_peer_pid = peers.iter().max().unwrap();
+        let max_peer_pid = peers.iter().max().unwrap_or(&NodeId::MIN);
         let max_pid = *std::cmp::max(max_peer_pid, &pid) as usize;
         let mut outgoing = Vec::with_capacity(config.buffer_size);
         let (state, leader) = match storage

--- a/omnipaxos/tests/flexible_quorum_test.rs
+++ b/omnipaxos/tests/flexible_quorum_test.rs
@@ -12,6 +12,12 @@ use utils::{verification::verify_log, TestConfig, TestSystem, Value};
 fn flexible_quorum_prepare_phase_test() {
     // Start Kompact system
     let cfg = TestConfig::load("flexible_quorum_test").expect("Test config couldn't be loaded");
+
+    if cfg.num_nodes < 2 {
+        // this test needs at least two nodes because it kills the leader
+        return;
+    }
+
     let mut sys = TestSystem::with(cfg);
     sys.start_all_nodes();
 
@@ -22,7 +28,7 @@ fn flexible_quorum_prepare_phase_test() {
     let expected_log: Vec<Value> = (0..cfg.num_proposals).map(Value::with_id).collect();
 
     // Propose some initial values
-    sys.make_proposals(2, initial_proposals, cfg.wait_timeout);
+    sys.make_proposals(1, initial_proposals, cfg.wait_timeout);
     let leader_id = sys.get_elected_leader(1, cfg.wait_timeout);
 
     // Kill maximum number of nodes (including leader) such that cluster can still function
@@ -38,7 +44,7 @@ fn flexible_quorum_prepare_phase_test() {
     // Wait for next leader to get elected
     thread::sleep(8 * cfg.election_timeout);
 
-    // Make some propsals
+    // Make some proposals
     let still_alive_node_id = sys.nodes.keys().next().unwrap();
     let still_alive_node = sys.nodes.get(still_alive_node_id).unwrap();
     sys.make_proposals(*still_alive_node_id, last_proposals, cfg.wait_timeout);
@@ -65,7 +71,7 @@ fn flexible_quorum_accept_phase_test() {
     let expected_log: Vec<Value> = (0..cfg.num_proposals).map(Value::with_id).collect();
 
     // Propose some values
-    sys.make_proposals(2, initial_proposals, cfg.wait_timeout);
+    sys.make_proposals(1, initial_proposals, cfg.wait_timeout);
     let leader_id = sys.get_elected_leader(1, cfg.wait_timeout);
 
     // Kill maximum number of followers such that leader can still function


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

Fix #143.

## Changes

This commit enables OmniPaxos to run with a single peer. What needed to
be changed is to call the proper handle methods instead of directly
updating the LeaderState with one's own promise and accepted index. By
using the handle methods, we ensure that all required actions (e.g. updating
the decided index, becoming a leader) are properly triggered.

These changes were tested by running the following tests with a single node:

* ble_test
* consensus_test
* unicache_test
* flexible_quorum_test
* trim_test
* batching_test

The other integration tests require more than 1 peer in order to test follower
behavior.