### PR TITLE
Prevent infinite source recursion in ConfigError

### DIFF
--- a/examples/dashboard/src/util.rs
+++ b/examples/dashboard/src/util.rs
@@ -51,7 +51,8 @@ pub(crate) fn parse_arguments() -> Result<(u64, u64, Duration, u64), String> {
             }
             "duration" => {
                 i += 1;
-                duration_in_seconds = args[i].parse().expect("Invalid duration."); // Set the default duration to 10
+                duration_in_seconds = args[i].parse().expect("Invalid duration.");
+                // Set the default duration to 10
             }
             "crash" => {
                 i += 1;

--- a/omnipaxos/src/errors.rs
+++ b/omnipaxos/src/errors.rs
@@ -19,24 +19,24 @@ pub enum ConfigError {
 
 impl fmt::Display for ConfigError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             #[cfg(feature = "toml_config")]
-            ConfigError::ReadFile(ref err) => write!(f, "{}", err),
+            ConfigError::ReadFile(err) => write!(f, "{}", err),
             #[cfg(feature = "toml_config")]
-            ConfigError::Parse(ref err) => write!(f, "{}", err),
-            ConfigError::InvalidConfig(ref str) => write!(f, "Invalid config: {}", str),
+            ConfigError::Parse(err) => write!(f, "{}", err),
+            ConfigError::InvalidConfig(str) => write!(f, "Invalid config: {}", str),
         }
     }
 }
 
 impl error::Error for ConfigError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match *self {
+        match self {
             #[cfg(feature = "toml_config")]
-            ConfigError::ReadFile(ref err) => Some(err),
+            ConfigError::ReadFile(err) => Some(err),
             #[cfg(feature = "toml_config")]
-            ConfigError::Parse(ref err) => Some(err),
-            ConfigError::InvalidConfig(_) => Some(self),
+            ConfigError::Parse(err) => Some(err),
+            ConfigError::InvalidConfig(_) => None,
         }
     }
 }


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)

## Issues

This fixes #145.

## Other Changes

Returning itself when calling Error::source seems to break the formatting when converting the ConfigError into anyhow::Error. On my machine and env, it seemed to silently crash a Tokio task.