### PR TITLE
Puts RocksDB build behind feature flag "persistent_storage"

### DIFF
--- a/docs/omnipaxos/features.md
+++ b/docs/omnipaxos/features.md
@@ -7,6 +7,6 @@ OmniPaxos provide several features that can be used to enhance both usability an
 - `macros` - Macros for convenience, e.g., deriving blanket implementations for OmniPaxos traits.
 
 ## `omnipaxos_storage` feature flags
-- `persistent_storage` - RocksDB-backed storage implementation for OmniPaxos state. Allows for recovery even if all nodes in a cluster fail.
+- `persistent_storage` - a persistent storage implementation using RocksDB.
 
 Configure the features in your `Cargo.toml` file.

--- a/docs/omnipaxos/features.md
+++ b/docs/omnipaxos/features.md
@@ -1,9 +1,12 @@
 OmniPaxos provide several features that can be used to enhance both usability and performance:
 
-- `persistent_storage` - RocksDB-backed storage implementation for OmniPaxos state. Allows for recovery even if all nodes in a cluster fail.
+## `omnipaxos` feature flags
 - `logging` - System-wide logging with the slog crate.
 - `toml_config` - Create an OmniPaxos instance from a TOML configuration file.
 - `serde` - Serialization and deserialization of messages and internal structs with serde. This makes it convenient to use with any desired network implementation without having to implement your own serializer and deserializer.
 - `macros` - Macros for convenience, e.g., deriving blanket implementations for OmniPaxos traits.
+
+## `omnipaxos_storage` feature flags
+- `persistent_storage` - RocksDB-backed storage implementation for OmniPaxos state. Allows for recovery even if all nodes in a cluster fail.
 
 Configure the features in your `Cargo.toml` file.

--- a/docs/omnipaxos/features.md
+++ b/docs/omnipaxos/features.md
@@ -1,5 +1,6 @@
 OmniPaxos provide several features that can be used to enhance both usability and performance:
 
+- `persistent_storage` - RocksDB-backed storage implementation for OmniPaxos state. Allows for recovery even if all nodes in a cluster fail.
 - `logging` - System-wide logging with the slog crate.
 - `toml_config` - Create an OmniPaxos instance from a TOML configuration file.
 - `serde` - Serialization and deserialization of messages and internal structs with serde. This makes it convenient to use with any desired network implementation without having to implement your own serializer and deserializer.

--- a/docs/omnipaxos/storage.md
+++ b/docs/omnipaxos/storage.md
@@ -124,7 +124,7 @@ impl<T> Storage<T> for MemoryStorage<T>
 ```
 
 ## PersistentStorage
-`PersistentStorage` is a persistent storage implementation, built on top of [RocksDB](https://crates.io/crates/rocksdb), that stores the replicated log and the state of OmniPaxos. Users can configure the path to log entries and OmniPaxos state, and storage-related options through `PersistentStorageConfig`. The configuration struct features a `default()` constructor for generating default configuration, and the constructor `with()` that takes the storage path and options as arguments.
+`PersistentStorage` is a persistent storage implementation, built on top of [RocksDB](https://crates.io/crates/rocksdb), that stores the replicated log and the state of OmniPaxos. It can be enabled with the "persistent_storage" feature flag. Users can configure the path to log entries and OmniPaxos state, and storage-related options through `PersistentStorageConfig`. The configuration struct features a `default()` constructor for generating default configuration, and the constructor `with()` that takes the storage path and options as arguments.
 
 ```toml
 [dependencies]

--- a/docs/omnipaxos/storage.md
+++ b/docs/omnipaxos/storage.md
@@ -2,9 +2,9 @@ You are free to use any storage implementation with `OmniPaxos`. The only requir
 
 ## Importing `omnipaxos_storage`
 To use the provided storage implementations, we need to add `omnipaxos_storage` to the dependencies in the cargo file. You can find the latest version on [crates](https://crates.io/crates/omnipaxos_storage).
-```rust
+```toml
 [dependencies]
-omnipaxos_storage = { version = "LATEST_VERSION", default-features = true } 
+omnipaxos_storage = { version = "LATEST_VERSION", default-features = true }
 ```
 
 **If** you **do** decide to implement your own storage, we recommend taking a look at `MemoryStorage` as a reference for implementing the functions required by `Storage`.
@@ -125,6 +125,13 @@ impl<T> Storage<T> for MemoryStorage<T>
 
 ## PersistentStorage
 `PersistentStorage` is a persistent storage implementation, built on top of [RocksDB](https://crates.io/crates/rocksdb), that stores the replicated log and the state of OmniPaxos. Users can configure the path to log entries and OmniPaxos state, and storage-related options through `PersistentStorageConfig`. The configuration struct features a `default()` constructor for generating default configuration, and the constructor `with()` that takes the storage path and options as arguments.
+
+```toml
+[dependencies]
+omnipaxos_storage = { version = "LATEST_VERSION", features=["persistent_storage"] }
+```
+The persistent storage implementation must first be enabled via the "persistent_storage" feature flag.
+
 ```rust
 use omnipaxos_storage::{
     persistent_storage::{PersistentStorage, PersistentStorageConfig},

--- a/examples/dashboard/src/util.rs
+++ b/examples/dashboard/src/util.rs
@@ -51,7 +51,7 @@ pub(crate) fn parse_arguments() -> Result<(u64, u64, Duration, u64), String> {
             }
             "duration" => {
                 i += 1;
-                duration_in_seconds = args[i].parse().expect("Invalid duration."); // Set the default duration to 10
+                duration_in_seconds = args[i].parse().expect("Invalid duration.");
             }
             "crash" => {
                 i += 1;

--- a/omnipaxos/Cargo.toml
+++ b/omnipaxos/Cargo.toml
@@ -25,8 +25,8 @@ num-traits = { version = "0.2.16", optional = true }
 linked_hash_set = { version = "0.1.4", optional = true }
 
 [dev-dependencies]
-kompact = { git = "https://github.com/kompics/kompact", rev = "94956af", features = ["silent_logging"] }
-omnipaxos_storage = { path = "../omnipaxos_storage", default-features = true } 
+kompact = { git = "https://github.com/kompics/kompact", rev = "4fd1fdc", features = ["silent_logging"] }
+omnipaxos_storage = { path = "../omnipaxos_storage", features = ["persistent_storage"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.7.3"
 tempfile = "3.3.0"

--- a/omnipaxos/Cargo.toml
+++ b/omnipaxos/Cargo.toml
@@ -37,6 +37,7 @@ serde_json = "1.0"
 [features]
 logging  = ["slog", "slog-term", "slog-async"]
 toml_config = ["serde", "toml"]
+serde = ["serde"]
 macros = ["omnipaxos_macros"]
 unicache = ["lru", "num-traits", "linked_hash_set"]
 

--- a/omnipaxos/Cargo.toml
+++ b/omnipaxos/Cargo.toml
@@ -37,7 +37,6 @@ serde_json = "1.0"
 [features]
 logging  = ["slog", "slog-term", "slog-async"]
 toml_config = ["serde", "toml"]
-serde = ["serde"]
 macros = ["omnipaxos_macros"]
 unicache = ["lru", "num-traits", "linked_hash_set"]
 

--- a/omnipaxos/tests/ble_test.rs
+++ b/omnipaxos/tests/ble_test.rs
@@ -20,7 +20,7 @@ fn ble_test() {
     let num_elections = cfg.num_nodes / 2;
     for _ in 0..num_elections {
         // Wait to ensure stabilized leader
-        thread::sleep(8 * cfg.election_timeout);
+        thread::sleep(10 * cfg.election_timeout);
         let alive_node = sys
             .nodes
             .keys()

--- a/omnipaxos/tests/flexible_quorum_test.rs
+++ b/omnipaxos/tests/flexible_quorum_test.rs
@@ -36,7 +36,7 @@ fn flexible_quorum_prepare_phase_test() {
     sys.kill_node(leader_id);
 
     // Wait for next leader to get elected
-    thread::sleep(8 * cfg.election_timeout);
+    thread::sleep(10 * cfg.election_timeout);
 
     // Make some propsals
     let still_alive_node_id = sys.nodes.keys().next().unwrap();
@@ -77,7 +77,7 @@ fn flexible_quorum_accept_phase_test() {
     }
 
     // Wait for next leader to get elected
-    thread::sleep(8 * cfg.election_timeout);
+    thread::sleep(10 * cfg.election_timeout);
 
     // Make some more propsals
     sys.make_proposals(leader_id, last_proposals, cfg.wait_timeout);

--- a/omnipaxos/tests/sync_test.rs
+++ b/omnipaxos/tests/sync_test.rs
@@ -196,7 +196,7 @@ fn sync_test(test: SyncTest) {
     });
 
     // Wait a bit so next leader is stabilized (otherwise we can lose proposals)
-    std::thread::sleep(8 * cfg.election_timeout);
+    std::thread::sleep(10 * cfg.election_timeout);
     let node = sys.nodes.keys().find(|x| **x != follower_id).unwrap(); // a node that can actually see the current leader.
     let leader_id = sys.get_elected_leader(*node, cfg.wait_timeout);
     assert_ne!(follower_id, leader_id, "New leader must be chosen!");

--- a/omnipaxos_storage/Cargo.toml
+++ b/omnipaxos_storage/Cargo.toml
@@ -15,9 +15,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 omnipaxos = { version = "0.2.2", path = "../omnipaxos", features = ["serde"] }
-serde = { version = "1.0", features = ["derive"] }
-bincode = "1.3.3"
-zerocopy = "0.6.1"
-rocksdb = "0.21.0"
+serde = { version = "1.0", features = ["derive"], optional= true }
+bincode = { version = "1.3.3", optional = true }
+zerocopy = { version = "0.6.1", optional = true }
+rocksdb = { version = "0.21.0", optional = true }
 [profile.release]
 lto = true
+
+[features]
+persistent_storage = ["dep:rocksdb", "dep:serde", "dep:bincode", "dep:zerocopy"]

--- a/omnipaxos_storage/src/lib.rs
+++ b/omnipaxos_storage/src/lib.rs
@@ -6,4 +6,5 @@
 pub mod memory_storage;
 
 /// an on-disk storage implementation with persistence for the replica state and the log.
+#[cfg(feature = "persistent_storage")]
 pub mod persistent_storage;


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Issues

#135 

## Breaking Changes

Users of PersistentStorage will now need to enable the "persistent_storage" feature flag.