### PR TITLE
become_leader() API

### DIFF
--- a/omnipaxos/src/ballot_leader_election.rs
+++ b/omnipaxos/src/ballot_leader_election.rs
@@ -205,7 +205,11 @@ impl BallotLeaderElection {
         self.new_hb_round();
         if seq_paxos_promise > self.leader {
             // Sync leader with Paxos promise in case ballot didn't make it to BLE followers
+            // or become_leader() was called.
             self.leader = seq_paxos_promise;
+            if seq_paxos_promise.pid == self.pid {
+                self.current_ballot = seq_paxos_promise;
+            }
             self.happy = true;
         }
         if self.leader == self.current_ballot {

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -394,10 +394,12 @@ where
         }
     }
 
-    /// Manually attempt to become the leader with the round number `n`.
-    pub fn become_leader(&mut self, n: u32) {
+    /// Manually attempt to become the leader by incrementing this instance's Ballot. Calling this
+    /// function may not result in gainig leadership if other instances are competing for
+    /// leadership with higher Ballots.
+    pub fn try_become_leader(&mut self) {
         let mut my_ballot = self.ble.get_current_ballot();
-        my_ballot.n = n;
+        my_ballot.n += 1;
         self.seq_paxos.handle_leader(my_ballot);
     }
 

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -394,6 +394,13 @@ where
         }
     }
 
+    /// Manually attempt to become the leader with the round number `n`.
+    pub fn become_leader(&mut self, n: u32) {
+        let mut my_ballot = self.ble.get_current_ballot();
+        my_ballot.n = n;
+        self.seq_paxos.handle_leader(my_ballot);
+    }
+
     /*** BLE calls ***/
     /// Update the custom priority used in the Ballot for this server. Note that changing the
     /// priority triggers a leader re-election.

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -336,9 +336,9 @@ where
 pub(crate) mod defaults {
     pub(crate) const BUFFER_SIZE: usize = 100000;
     pub(crate) const BLE_BUFFER_SIZE: usize = 100;
-    pub(crate) const ELECTION_TIMEOUT: u64 = 10;
-    pub(crate) const RESEND_MESSAGE_TIMEOUT: u64 = 1000;
-    pub(crate) const FLUSH_BATCH_TIMEOUT: u64 = 2000;
+    pub(crate) const ELECTION_TIMEOUT: u64 = 1;
+    pub(crate) const RESEND_MESSAGE_TIMEOUT: u64 = 100;
+    pub(crate) const FLUSH_BATCH_TIMEOUT: u64 = 200;
 }
 
 #[allow(missing_docs)]


### PR DESCRIPTION
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [ ] You updated the OmniPaxos book (if applicable)

## Issues
[omnipaxos-kv Issue #1](https://github.com/haraldng/omnipaxos-kv/issues/1)

## Other Changes
Changes ELECTION_TIMEOUT, RESEND_MESSAGE_TIMEOUT, and FLUSH_BATCH_TIMEOUT to have more reasonable/intuitive defaults. (Your election timeout corresponds to how often you call tick and you scale resend message and flush batch timeouts accordingly)
