### PR TITLE
Outgoing messages buffer reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,14 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - name: Use the cache to share dependencies # keyed by Cargo.lock
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      # - name: Use the cache to share dependencies # keyed by Cargo.lock
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ~/.cargo/registry
+      #       ~/.cargo/git
+      #       target
+      #     key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,14 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      # - name: Use the cache to share dependencies # keyed by Cargo.lock
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.cargo/registry
-      #       ~/.cargo/git
-      #       target
-      #     key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Use the cache to share dependencies # keyed by Cargo.lock
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Run tests

--- a/docs/omnipaxos/communication.md
+++ b/docs/omnipaxos/communication.md
@@ -15,7 +15,9 @@ By handling incoming messages and local calls such as `append()`, our local `omn
 
 ```rust
 // send outgoing messages. This should be called periodically, e.g. every ms
-for out_msg in omni_paxos.outgoing_messages() {
+let mut msg_buffer = Vec::new();
+omni_paxos.outgoing_messages(&mut msg_buffer);
+for out_msg in msg_buffer.drain(..) {
     let receiver = out_msg.get_receiver();
     // send out_msg to receiver on network layer
 }

--- a/docs/omnipaxos/communication.md
+++ b/docs/omnipaxos/communication.md
@@ -15,8 +15,8 @@ By handling incoming messages and local calls such as `append()`, our local `omn
 
 ```rust
 // send outgoing messages. This should be called periodically, e.g. every ms
-let mut msg_buffer = Vec::new();
-omni_paxos.outgoing_messages(&mut msg_buffer);
+let mut msg_buffer = Vec::with_capacity(1000);
+omni_paxos.take_outgoing_messages(&mut msg_buffer);
 for out_msg in msg_buffer.drain(..) {
     let receiver = out_msg.get_receiver();
     // send out_msg to receiver on network layer

--- a/examples/dashboard/src/main.rs
+++ b/examples/dashboard/src/main.rs
@@ -61,6 +61,7 @@ fn main() {
             omni_paxos: Arc::clone(&omni_paxos),
             incoming: receiver_channels.remove(pid).unwrap(),
             outgoing: sender_channels.clone(),
+            message_buffer: vec![],
         };
         let join_handle = runtime.spawn({
             async move {

--- a/examples/dashboard/src/server.rs
+++ b/examples/dashboard/src/server.rs
@@ -24,7 +24,7 @@ impl OmniPaxosServer {
         self.omni_paxos
             .lock()
             .unwrap()
-            .outgoing_messages(&mut self.message_buffer);
+            .take_outgoing_messages(&mut self.message_buffer);
         for msg in self.message_buffer.drain(..) {
             let receiver = msg.get_receiver();
             let channel = self

--- a/examples/dashboard/src/server.rs
+++ b/examples/dashboard/src/server.rs
@@ -16,12 +16,16 @@ pub struct OmniPaxosServer {
     pub omni_paxos: Arc<Mutex<OmniPaxosLog>>,
     pub incoming: mpsc::Receiver<Message<LogEntry>>,
     pub outgoing: HashMap<NodeId, mpsc::Sender<Message<LogEntry>>>,
+    pub message_buffer: Vec<Message<LogEntry>>,
 }
 
 impl OmniPaxosServer {
     async fn send_outgoing_msgs(&mut self) {
-        let messages = self.omni_paxos.lock().unwrap().outgoing_messages();
-        for msg in messages {
+        self.omni_paxos
+            .lock()
+            .unwrap()
+            .outgoing_messages(&mut self.message_buffer);
+        for msg in self.message_buffer.drain(..) {
             let receiver = msg.get_receiver();
             let channel = self
                 .outgoing

--- a/examples/kv_store/src/main.rs
+++ b/examples/kv_store/src/main.rs
@@ -68,6 +68,7 @@ fn main() {
             omni_paxos: Arc::clone(&omni_paxos),
             incoming: receiver_channels.remove(&pid).unwrap(),
             outgoing: sender_channels.clone(),
+            message_buffer: vec![],
         };
         let join_handle = runtime.spawn({
             async move {

--- a/examples/kv_store/src/server.rs
+++ b/examples/kv_store/src/server.rs
@@ -15,12 +15,16 @@ pub struct OmniPaxosServer {
     pub omni_paxos: Arc<Mutex<OmniPaxosKV>>,
     pub incoming: mpsc::Receiver<Message<KeyValue>>,
     pub outgoing: HashMap<NodeId, mpsc::Sender<Message<KeyValue>>>,
+    pub message_buffer: Vec<Message<KeyValue>>,
 }
 
 impl OmniPaxosServer {
     async fn send_outgoing_msgs(&mut self) {
-        let messages = self.omni_paxos.lock().unwrap().outgoing_messages();
-        for msg in messages {
+        self.omni_paxos
+            .lock()
+            .unwrap()
+            .outgoing_messages(&mut self.message_buffer);
+        for msg in self.message_buffer.drain(..) {
             let receiver = msg.get_receiver();
             let channel = self
                 .outgoing

--- a/examples/kv_store/src/server.rs
+++ b/examples/kv_store/src/server.rs
@@ -23,7 +23,7 @@ impl OmniPaxosServer {
         self.omni_paxos
             .lock()
             .unwrap()
-            .outgoing_messages(&mut self.message_buffer);
+            .take_outgoing_messages(&mut self.message_buffer);
         for msg in self.message_buffer.drain(..) {
             let receiver = msg.get_receiver();
             let channel = self

--- a/omnipaxos/src/ballot_leader_election.rs
+++ b/omnipaxos/src/ballot_leader_election.rs
@@ -205,7 +205,11 @@ impl BallotLeaderElection {
         self.new_hb_round();
         if seq_paxos_promise > self.leader {
             // Sync leader with Paxos promise in case ballot didn't make it to BLE followers
+            // or become_leader() was called.
             self.leader = seq_paxos_promise;
+            if seq_paxos_promise.pid == self.pid {
+                self.current_ballot = seq_paxos_promise;
+            }
             self.happy = true;
         }
         if self.leader == self.current_ballot {

--- a/omnipaxos/src/ballot_leader_election.rs
+++ b/omnipaxos/src/ballot_leader_election.rs
@@ -157,7 +157,7 @@ impl BallotLeaderElection {
     }
 
     /// Returns reference to outgoing messages
-    pub(crate) fn get_outgoing(&mut self) -> &mut Vec<BLEMessage> {
+    pub(crate) fn outgoing_mut(&mut self) -> &mut Vec<BLEMessage> {
         &mut self.outgoing
     }
 

--- a/omnipaxos/src/ballot_leader_election.rs
+++ b/omnipaxos/src/ballot_leader_election.rs
@@ -156,9 +156,9 @@ impl BallotLeaderElection {
         self.current_ballot.priority = p;
     }
 
-    /// Returns outgoing messages
-    pub(crate) fn get_outgoing_msgs(&mut self) -> Vec<BLEMessage> {
-        std::mem::take(&mut self.outgoing)
+    /// Returns reference to outgoing messages
+    pub(crate) fn get_outgoing(&mut self) -> &mut Vec<BLEMessage> {
+        &mut self.outgoing
     }
 
     /// Handle an incoming message.

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -394,10 +394,12 @@ where
         }
     }
 
-    /// Manually attempt to become the leader with the round number `n`.
-    pub fn become_leader(&mut self, n: u32) {
+    /// Manually attempt to become the leader by incrementing this instance's Ballot. Calling this
+    /// function may not result in gainig leadership if other instances are competing for
+    /// leadership with higher Ballots.
+    pub fn try_become_leader(&mut self) {
         let mut my_ballot = self.ble.get_current_ballot();
-        my_ballot.n = n;
+        my_ballot.n += 1;
         self.seq_paxos.handle_leader(my_ballot);
     }
 

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -289,19 +289,10 @@ where
         self.seq_paxos.get_promise()
     }
 
-    /// Returns the outgoing messages from this server. The messages should then be sent via the network implementation.
-    pub fn outgoing_messages(&mut self) -> Vec<Message<T>> {
-        let paxos_msgs = self
-            .seq_paxos
-            .get_outgoing_msgs()
-            .into_iter()
-            .map(|p| Message::SequencePaxos(p));
-        let ble_msgs = self
-            .ble
-            .get_outgoing_msgs()
-            .into_iter()
-            .map(|b| Message::BLE(b));
-        ble_msgs.chain(paxos_msgs).collect()
+    /// Moves outgoing messages from this server into the buffer. The messages should then be sent via the network implementation.
+    pub fn outgoing_messages(&mut self, buffer: &mut Vec<Message<T>>) {
+        self.seq_paxos.get_outgoing_msgs(buffer);
+        buffer.extend(self.ble.get_outgoing().drain(..).map(|b| Message::BLE(b)));
     }
 
     /// Read entry at index `idx` in the log. Returns `None` if `idx` is out of bounds.

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -394,6 +394,13 @@ where
         }
     }
 
+    /// Manually attempt to become the leader with the round number `n`.
+    pub fn become_leader(&mut self, n: u32) {
+        let mut my_ballot = self.ble.get_current_ballot();
+        my_ballot.n = n;
+        self.seq_paxos.handle_leader(my_ballot);
+    }
+
     /*** BLE calls ***/
     /// Update the custom priority used in the Ballot for this server. Note that changing the
     /// priority triggers a leader re-election.

--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -290,9 +290,9 @@ where
     }
 
     /// Moves outgoing messages from this server into the buffer. The messages should then be sent via the network implementation.
-    pub fn outgoing_messages(&mut self, buffer: &mut Vec<Message<T>>) {
-        self.seq_paxos.get_outgoing_msgs(buffer);
-        buffer.extend(self.ble.get_outgoing().drain(..).map(|b| Message::BLE(b)));
+    pub fn take_outgoing_messages(&mut self, buffer: &mut Vec<Message<T>>) {
+        self.seq_paxos.take_outgoing_msgs(buffer);
+        buffer.extend(self.ble.outgoing_mut().drain(..).map(|b| Message::BLE(b)));
     }
 
     /// Read entry at index `idx` in the log. Returns `None` if `idx` is out of bounds.

--- a/omnipaxos/src/sequence_paxos/follower.rs
+++ b/omnipaxos/src/sequence_paxos/follower.rs
@@ -158,8 +158,8 @@ where
     }
 
     fn reply_accepted(&mut self, n: Ballot, accepted_idx: usize) {
-        let buffered_accepted = self.get_buffered_accepted_message(n);
-        match buffered_accepted {
+        let latest_accepted = self.get_latest_accepted_message(n);
+        match latest_accepted {
             Some(acc) => acc.accepted_idx = accepted_idx,
             None => {
                 let accepted = Accepted { n, accepted_idx };
@@ -174,7 +174,7 @@ where
         }
     }
 
-    fn get_buffered_accepted_message(&mut self, n: Ballot) -> Option<&mut Accepted> {
+    fn get_latest_accepted_message(&mut self, n: Ballot) -> Option<&mut Accepted> {
         if let Some((ballot, outgoing_idx)) = &self.latest_accepted_meta {
             if *ballot == n {
                 if let Message::SequencePaxos(PaxosMessage {
@@ -185,11 +185,11 @@ where
                     return Some(a);
                 } else {
                     #[cfg(feature = "logging")]
-                    warn!(self.logger, "Cached idx is not an Accepted message!");
+                    debug!(self.logger, "Cached idx is not an Accepted message!");
                 }
             }
         }
-        return None;
+        None
     }
 
     /// Also returns whether the message's ballot was promised

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -246,7 +246,7 @@ where
     }
 
     /// Moves the outgoing messages from this replica into the buffer. The messages should then be sent via the network implementation.
-    /// If the buffer is empty it can be efficently swapped, otherwise messages must be copied into
+    /// If `buffer` is empty, it gets swapped with the internal message buffer. Otherwise, messages are appended to the buffer. This prevents messages from getting discarded.
     /// the buffer.
     pub(crate) fn take_outgoing_msgs(&mut self, buffer: &mut Vec<Message<T>>) {
         if buffer.is_empty() {

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -255,7 +255,7 @@ where
             // User has unsent messages in their buffer, must extend their buffer.
             buffer.append(&mut self.outgoing);
         }
-        self.leader_state.reset_batch_accept_meta();
+        self.leader_state.reset_latest_accept_meta();
         self.latest_accepted_meta = None;
     }
 

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -246,10 +246,13 @@ where
     }
 
     /// Moves the outgoing messages from this replica into the buffer. The messages should then be sent via the network implementation.
-    pub(crate) fn get_outgoing_msgs(&mut self, buffer: &mut Vec<Message<T>>) {
+    /// If the buffer is empty it can be efficently swapped, otherwise messages must be copied into
+    /// the buffer.
+    pub(crate) fn take_outgoing_msgs(&mut self, buffer: &mut Vec<Message<T>>) {
         if buffer.is_empty() {
             std::mem::swap(buffer, &mut self.outgoing);
         } else {
+            // User has unsent messages in their buffer, must extend their buffer.
             buffer.append(&mut self.outgoing);
         }
         self.leader_state.reset_batch_accept_meta();

--- a/omnipaxos/src/sequence_paxos/mod.rs
+++ b/omnipaxos/src/sequence_paxos/mod.rs
@@ -2,6 +2,7 @@ use super::{ballot_leader_election::Ballot, messages::sequence_paxos::*, util::L
 #[cfg(feature = "logging")]
 use crate::utils::logger::create_logger;
 use crate::{
+    messages::Message,
     storage::{
         internal_storage::{InternalStorage, InternalStorageConfig},
         Entry, Snapshot, StopSign, Storage,
@@ -32,13 +33,12 @@ where
     state: (Role, Phase),
     buffered_proposals: Vec<T>,
     buffered_stopsign: Option<StopSign>,
-    outgoing: Vec<PaxosMessage<T>>,
+    outgoing: Vec<Message<T>>,
     leader_state: LeaderState<T>,
     latest_accepted_meta: Option<(Ballot, usize)>,
     // Keeps track of sequence of accepts from leader where AcceptSync = 1
     current_seq_num: SequenceNumber,
     cached_promise_message: Option<Promise<T>>,
-    buffer_size: usize,
     #[cfg(feature = "logging")]
     logger: Logger,
 }
@@ -67,11 +67,11 @@ where
                 let state = (Role::Follower, Phase::Recover);
                 for peer_pid in &peers {
                     let prepreq = PrepareReq { n: b };
-                    outgoing.push(PaxosMessage {
+                    outgoing.push(Message::SequencePaxos(PaxosMessage {
                         from: pid,
                         to: *peer_pid,
                         msg: PaxosMsg::PrepareReq(prepreq),
-                    });
+                    }));
                 }
                 (state, b)
             }
@@ -97,7 +97,6 @@ where
             latest_accepted_meta: None,
             current_seq_num: SequenceNumber::default(),
             cached_promise_message: None,
-            buffer_size: config.buffer_size,
             #[cfg(feature = "logging")]
             logger: {
                 if let Some(logger) = config.custom_logger {
@@ -162,11 +161,11 @@ where
                 if result.is_ok() {
                     for pid in &self.peers {
                         let msg = PaxosMsg::Compaction(Compaction::Trim(trimmed_idx));
-                        self.outgoing.push(PaxosMessage {
+                        self.outgoing.push(Message::SequencePaxos(PaxosMessage {
                             from: self.pid,
                             to: *pid,
                             msg,
-                        });
+                        }));
                     }
                 }
                 result.map_err(|e| {
@@ -192,11 +191,11 @@ where
             // since it is decided, it is ok even for a follower to send this
             for pid in &self.peers {
                 let msg = PaxosMsg::Compaction(Compaction::Snapshot(idx));
-                self.outgoing.push(PaxosMessage {
+                self.outgoing.push(Message::SequencePaxos(PaxosMessage {
                     from: self.pid,
                     to: *pid,
                     msg,
-                });
+                }));
             }
         }
         result.map_err(|e| {
@@ -246,13 +245,15 @@ where
         }
     }
 
-    /// Returns the outgoing messages from this replica. The messages should then be sent via the network implementation.
-    pub(crate) fn get_outgoing_msgs(&mut self) -> Vec<PaxosMessage<T>> {
-        let mut outgoing = Vec::with_capacity(self.buffer_size);
-        std::mem::swap(&mut self.outgoing, &mut outgoing);
+    /// Moves the outgoing messages from this replica into the buffer. The messages should then be sent via the network implementation.
+    pub(crate) fn get_outgoing_msgs(&mut self, buffer: &mut Vec<Message<T>>) {
+        if buffer.is_empty() {
+            std::mem::swap(buffer, &mut self.outgoing);
+        } else {
+            buffer.append(&mut self.outgoing);
+        }
         self.leader_state.reset_batch_accept_meta();
         self.latest_accepted_meta = None;
-        outgoing
     }
 
     /// Handle an incoming message.
@@ -340,11 +341,11 @@ where
         let prepreq = PrepareReq {
             n: self.get_promise(),
         };
-        self.outgoing.push(PaxosMessage {
+        self.outgoing.push(Message::SequencePaxos(PaxosMessage {
             from: self.pid,
             to: pid,
             msg: PaxosMsg::PrepareReq(prepreq),
-        });
+        }));
     }
 
     fn propose_entry(&mut self, entry: T) {
@@ -363,11 +364,11 @@ where
         let leader = self.get_current_leader();
         if leader > 0 && self.pid != leader {
             let pf = PaxosMsg::ProposalForward(entries);
-            let msg = PaxosMessage {
+            let msg = Message::SequencePaxos(PaxosMessage {
                 from: self.pid,
                 to: leader,
                 msg: pf,
-            };
+            });
             self.outgoing.push(msg);
         } else {
             self.buffered_proposals.append(&mut entries);
@@ -380,11 +381,11 @@ where
             #[cfg(feature = "logging")]
             trace!(self.logger, "Forwarding StopSign to Leader {:?}", leader);
             let fs = PaxosMsg::ForwardStopSign(ss);
-            let msg = PaxosMessage {
+            let msg = Message::SequencePaxos(PaxosMessage {
                 from: self.pid,
                 to: leader,
                 msg: fs,
-            };
+            });
             self.outgoing.push(msg);
         } else if self.buffered_stopsign.as_mut().is_none() {
             self.buffered_stopsign = Some(ss);

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -82,7 +82,7 @@ where
     pub accepted_indexes: Vec<usize>,
     max_promise_meta: PromiseMetaData,
     max_promise_sync: Option<LogSync<T>>,
-    batch_accept_meta: Vec<Option<(Ballot, usize)>>, //  index in outgoing
+    latest_accept_meta: Vec<Option<(Ballot, usize)>>, //  index in outgoing
     pub max_pid: usize,
     // The number of promises needed in the prepare phase to become synced and
     // the number of accepteds needed in the accept phase to decide an entry.
@@ -101,7 +101,7 @@ where
             accepted_indexes: vec![0; max_pid],
             max_promise_meta: PromiseMetaData::default(),
             max_promise_sync: None,
-            batch_accept_meta: vec![None; max_pid],
+            latest_accept_meta: vec![None; max_pid],
             max_pid,
             quorum,
         }
@@ -190,8 +190,8 @@ where
             .expect("Should be all initialised to 0!")
     }
 
-    pub fn reset_batch_accept_meta(&mut self) {
-        self.batch_accept_meta = vec![None; self.max_pid];
+    pub fn reset_latest_accept_meta(&mut self) {
+        self.latest_accept_meta = vec![None; self.max_pid];
     }
 
     pub fn get_promised_followers(&self) -> Vec<NodeId> {
@@ -219,17 +219,17 @@ where
             .collect()
     }
 
-    pub fn set_batch_accept_meta(&mut self, pid: NodeId, idx: Option<usize>) {
+    pub fn set_latest_accept_meta(&mut self, pid: NodeId, idx: Option<usize>) {
         let meta = idx.map(|x| (self.n_leader, x));
-        self.batch_accept_meta[Self::pid_to_idx(pid)] = meta;
+        self.latest_accept_meta[Self::pid_to_idx(pid)] = meta;
     }
 
     pub fn set_accepted_idx(&mut self, pid: NodeId, idx: usize) {
         self.accepted_indexes[Self::pid_to_idx(pid)] = idx;
     }
 
-    pub fn get_batch_accept_meta(&self, pid: NodeId) -> Option<(Ballot, usize)> {
-        self.batch_accept_meta
+    pub fn get_latest_accept_meta(&self, pid: NodeId) -> Option<(Ballot, usize)> {
+        self.latest_accept_meta
             .get(Self::pid_to_idx(pid))
             .unwrap()
             .as_ref()

--- a/omnipaxos/src/util.rs
+++ b/omnipaxos/src/util.rs
@@ -336,9 +336,9 @@ where
 pub(crate) mod defaults {
     pub(crate) const BUFFER_SIZE: usize = 100000;
     pub(crate) const BLE_BUFFER_SIZE: usize = 100;
-    pub(crate) const ELECTION_TIMEOUT: u64 = 10;
-    pub(crate) const RESEND_MESSAGE_TIMEOUT: u64 = 1000;
-    pub(crate) const FLUSH_BATCH_TIMEOUT: u64 = 2000;
+    pub(crate) const ELECTION_TIMEOUT: u64 = 1;
+    pub(crate) const RESEND_MESSAGE_TIMEOUT: u64 = 100;
+    pub(crate) const FLUSH_BATCH_TIMEOUT: u64 = 200;
 }
 
 #[allow(missing_docs)]

--- a/omnipaxos/tests/atomic_storage_test.rs
+++ b/omnipaxos/tests/atomic_storage_test.rs
@@ -111,7 +111,8 @@ fn _setup_leader() -> (
     });
     op.handle_incoming(setup_msg);
     op.tick(); // trigger leader change
-    let msgs = op.outgoing_messages();
+    let mut msgs = vec![];
+    op.outgoing_messages(&mut msgs);
     for msg in msgs {
         if let Message::SequencePaxos(ref px_msg) = msg {
             if let PaxosMsg::Prepare(prep) = px_msg.msg {
@@ -191,7 +192,7 @@ fn setup_follower() -> (
         }),
     });
     op.handle_incoming(setup_msg);
-    op.outgoing_messages();
+    op.outgoing_messages(&mut vec![]);
     assert!(
         op.get_current_leader().expect("should have leader").0 == 2,
         "node 2 should be leader"
@@ -523,7 +524,8 @@ fn atomic_storage_majority_promises_test() {
         });
         op.handle_incoming(setup_msg);
         op.tick(); // 1 gains leadership here
-        let msgs = op.outgoing_messages();
+        let mut msgs = vec![];
+        op.outgoing_messages(&mut msgs);
         for msg in msgs {
             if let Message::SequencePaxos(px_msg) = msg {
                 if let PaxosMsg::Prepare(prep) = px_msg.msg {

--- a/omnipaxos/tests/atomic_storage_test.rs
+++ b/omnipaxos/tests/atomic_storage_test.rs
@@ -112,7 +112,7 @@ fn _setup_leader() -> (
     op.handle_incoming(setup_msg);
     op.tick(); // trigger leader change
     let mut msgs = vec![];
-    op.outgoing_messages(&mut msgs);
+    op.take_outgoing_messages(&mut msgs);
     for msg in msgs {
         if let Message::SequencePaxos(ref px_msg) = msg {
             if let PaxosMsg::Prepare(prep) = px_msg.msg {
@@ -192,7 +192,7 @@ fn setup_follower() -> (
         }),
     });
     op.handle_incoming(setup_msg);
-    op.outgoing_messages(&mut vec![]);
+    op.take_outgoing_messages(&mut vec![]);
     assert!(
         op.get_current_leader().expect("should have leader").0 == 2,
         "node 2 should be leader"
@@ -525,7 +525,7 @@ fn atomic_storage_majority_promises_test() {
         op.handle_incoming(setup_msg);
         op.tick(); // 1 gains leadership here
         let mut msgs = vec![];
-        op.outgoing_messages(&mut msgs);
+        op.take_outgoing_messages(&mut msgs);
         for msg in msgs {
             if let Message::SequencePaxos(px_msg) = msg {
                 if let PaxosMsg::Prepare(prep) = px_msg.msg {

--- a/omnipaxos/tests/docs_integration.rs
+++ b/omnipaxos/tests/docs_integration.rs
@@ -178,8 +178,8 @@ mod docs_integration_test {
 
         // CODE_EXAMPLE
         // send outgoing messages. This should be called periodically, e.g. every ms
-        let mut msg_buffer = vec![];
-        omni_paxos.outgoing_messages(&mut msg_buffer);
+        let mut msg_buffer = Vec::with_capacity(1000);
+        omni_paxos.take_outgoing_messages(&mut msg_buffer);
         for out_msg in msg_buffer.drain(..) {
             let receiver = out_msg.get_receiver();
             // send out_msg to receiver on network layer

--- a/omnipaxos/tests/docs_integration.rs
+++ b/omnipaxos/tests/docs_integration.rs
@@ -178,7 +178,9 @@ mod docs_integration_test {
 
         // CODE_EXAMPLE
         // send outgoing messages. This should be called periodically, e.g. every ms
-        for out_msg in omni_paxos.outgoing_messages() {
+        let mut msg_buffer = vec![];
+        omni_paxos.outgoing_messages(&mut msg_buffer);
+        for out_msg in msg_buffer.drain(..) {
             let receiver = out_msg.get_receiver();
             // send out_msg to receiver on network layer
         }

--- a/omnipaxos/tests/reconnect_test.rs
+++ b/omnipaxos/tests/reconnect_test.rs
@@ -56,7 +56,7 @@ fn increasing_accept_seq_num_test() {
     for val in leaders_proposals {
         leader.on_definition(|x| {
             x.paxos.append(val).expect("Failed to append");
-            x.paxos.outgoing_messages(&mut outgoing_messages)
+            x.paxos.take_outgoing_messages(&mut outgoing_messages)
         });
 
         let seq_nums = outgoing_messages

--- a/omnipaxos/tests/reconnect_test.rs
+++ b/omnipaxos/tests/reconnect_test.rs
@@ -52,14 +52,15 @@ fn increasing_accept_seq_num_test() {
 
     // Get leader to propose more values and then collect cooresponding AcceptDecide messages
     let mut accept_seq_nums = vec![];
+    let mut outgoing_messages = vec![];
     for val in leaders_proposals {
-        let outgoing_messages = leader.on_definition(|x| {
+        leader.on_definition(|x| {
             x.paxos.append(val).expect("Failed to append");
-            x.paxos.outgoing_messages()
+            x.paxos.outgoing_messages(&mut outgoing_messages)
         });
 
         let seq_nums = outgoing_messages
-            .iter()
+            .drain(..)
             .filter_map(|msg| match msg {
                 Message::SequencePaxos(m) => Some(m),
                 _ => None,

--- a/omnipaxos/tests/sync_test.rs
+++ b/omnipaxos/tests/sync_test.rs
@@ -217,7 +217,7 @@ fn sync_test(test: SyncTest) {
         Some((_, write_quorum)) => write_quorum,
         None => cfg.num_nodes / 2 + 1,
     };
-    let num_nodes_to_stop = cfg.num_nodes - write_quorum_size; // one follower is already disconnected
+    let num_nodes_to_stop = cfg.num_nodes - (write_quorum_size-1); // one follower is already disconnected
     let nodes_to_stop = (1..=cfg.num_nodes as NodeId)
         .filter(|&n| n != follower_id && n != leader_id)
         .take(num_nodes_to_stop);

--- a/omnipaxos/tests/sync_test.rs
+++ b/omnipaxos/tests/sync_test.rs
@@ -217,7 +217,7 @@ fn sync_test(test: SyncTest) {
         Some((_, write_quorum)) => write_quorum,
         None => cfg.num_nodes / 2 + 1,
     };
-    let num_nodes_to_stop = cfg.num_nodes - write_quorum_size - 1; // -1 as leader and one follower are already disconnected
+    let num_nodes_to_stop = cfg.num_nodes - write_quorum_size; // one follower is already disconnected
     let nodes_to_stop = (1..=cfg.num_nodes as NodeId)
         .filter(|&n| n != follower_id && n != leader_id)
         .take(num_nodes_to_stop);

--- a/omnipaxos/tests/sync_test.rs
+++ b/omnipaxos/tests/sync_test.rs
@@ -217,7 +217,7 @@ fn sync_test(test: SyncTest) {
         Some((_, write_quorum)) => write_quorum,
         None => cfg.num_nodes / 2 + 1,
     };
-    let num_nodes_to_stop = cfg.num_nodes - (write_quorum_size-1); // one follower is already disconnected
+    let num_nodes_to_stop = cfg.num_nodes - write_quorum_size; // one follower is already disconnected
     let nodes_to_stop = (1..=cfg.num_nodes as NodeId)
         .filter(|&n| n != follower_id && n != leader_id)
         .take(num_nodes_to_stop);

--- a/omnipaxos/tests/utils.rs
+++ b/omnipaxos/tests/utils.rs
@@ -761,6 +761,7 @@ pub mod omnireplica {
         pub election_futures: Vec<Ask<(), Ballot>>,
         current_leader_ballot: Ballot,
         decided_idx: usize,
+        outgoing_buffer: Vec<Message<Value>>,
     }
 
     impl ComponentLifecycle for OmniPaxosComponent {
@@ -816,6 +817,7 @@ pub mod omnireplica {
                 decided_futures: HashMap::new(),
                 election_futures: vec![],
                 current_leader_ballot: Ballot::default(),
+                outgoing_buffer: Vec::new(),
             }
         }
 
@@ -824,9 +826,9 @@ pub mod omnireplica {
         }
 
         fn send_outgoing_msgs(&mut self) {
-            let outgoing = self.paxos.outgoing_messages();
-            for out in outgoing {
-                if self.is_connected_to(&out.get_receiver()) {
+            self.paxos.outgoing_messages(&mut self.outgoing_buffer);
+            for out in self.outgoing_buffer.drain(..) {
+                if !self.peer_disconnections.contains(&out.get_receiver()) {
                     match self.peers.get(&out.get_receiver()) {
                         Some(receiver) => receiver.tell(out),
                         None => warn!(
@@ -850,10 +852,6 @@ pub mod omnireplica {
                 true => self.peer_disconnections.remove(&pid),
                 false => self.peer_disconnections.insert(pid),
             };
-        }
-
-        pub fn is_connected_to(&self, pid: &NodeId) -> bool {
-            !self.peer_disconnections.contains(pid)
         }
 
         fn answer_election_future(&mut self, l: Ballot) {


### PR DESCRIPTION
Changes outgoing_messages() to take a buffer instead of allocating new vec.

Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)

## Issues

Fix #147 

## Breaking Changes
Changes the function signature of `OmniPaxos.get_outgoing`