### PR TITLE
Fix `try_become_leader` overtake leadership logic

### DIFF
--- a/omnipaxos/src/omni_paxos.rs
+++ b/omnipaxos/src/omni_paxos.rs
@@ -390,7 +390,8 @@ where
     /// leadership with higher Ballots.
     pub fn try_become_leader(&mut self) {
         let mut my_ballot = self.ble.get_current_ballot();
-        my_ballot.n += 1;
+        let promise = self.seq_paxos.get_promise();
+        my_ballot.n = promise.n + 1;
         self.seq_paxos.handle_leader(my_ballot);
     }
 


### PR DESCRIPTION
Quick fix for `try_become_leader`
- [x] You ran the local CI checker with `./check.sh` with no errors
- [x] You reference which issue is being closed in the PR text (if applicable)
- [x] You updated the OmniPaxos book (if applicable)