### PR TITLE
Fix `set_priority` to trigger election

### DIFF
--- a/omnipaxos/src/ballot_leader_election.rs
+++ b/omnipaxos/src/ballot_leader_election.rs
@@ -208,6 +208,12 @@ impl BallotLeaderElection {
             self.leader = seq_paxos_promise;
             self.happy = true;
         }
+
+        // Sync epoch with leader
+        if self.leader.n > self.current_ballot.n {
+            self.current_ballot.n = self.leader.n;
+        }
+
         if self.leader == self.current_ballot {
             Some(self.current_ballot)
         } else {
@@ -221,6 +227,10 @@ impl BallotLeaderElection {
             if max > self.leader {
                 self.leader = max;
             }
+        }
+
+        if self.current_ballot > self.leader {
+            self.leader = self.current_ballot;
         }
     }
 


### PR DESCRIPTION
As I understand from the comment on [set_priority](https://github.com/haraldng/omnipaxos/blob/master/omnipaxos/src/omni_paxos.rs#L399), setting a follower with a higher priority than the current leader is expected to trigger an election. However, this does not seem to happen in practice.

Changes I made in the PR that resolve this:

- `self.current_ballot` was not getting updated unless node becomes unhappy [(see here)](https://github.com/haraldng/omnipaxos/blob/master/omnipaxos/src/ballot_leader_election.rs#L269). This makes any "restarted" node to have lower epoch than its leader.

- Modified `update_leader` to consider `self.current_ballot` when updating `self.leader` .

These changes are based on my understanding of a node's priority, which is:
"In a cluster, a leader should not have a lower priority than any of its followers."
Let me know, if it is not true.
 
Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors 