### PR TITLE
Make storage error `Send + Sync + 'static`

### DIFF
--- a/omnipaxos/src/storage/mod.rs
+++ b/omnipaxos/src/storage/mod.rs
@@ -95,7 +95,7 @@ where
 }
 
 /// The Result type returned by the storage API.
-pub type StorageResult<T> = Result<T, Box<dyn Error>>;
+pub type StorageResult<T> = Result<T, Box<dyn Error + Send + Sync + 'static>>;
 
 /// The write operations of the storge implementation.
 #[derive(Debug)]


### PR DESCRIPTION
It is very common in applications that `Err` results are sent across
thread boundaries, which the missing bounds complicate unnecessarily.
Also makes the error compatible with `anyhow`.

---

Please make sure these boxes are checked, before submitting a new PR.

- [x] You ran the local CI checker with `./check.sh` with no errors
- [ ] You reference which issue is being closed in the PR text (if applicable)
- [ ] You updated the OmniPaxos book (if applicable)

