### PR TITLE
dump rocksdb version & expose metric related Datatypes

### DIFF
--- a/omnipaxos_storage/Cargo.toml
+++ b/omnipaxos_storage/Cargo.toml
@@ -18,7 +18,7 @@ omnipaxos = { version = "0.2.2", path = "../omnipaxos", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"], optional= true }
 bincode = { version = "1.3.3", optional = true }
 zerocopy = { version = "0.6.1", optional = true }
-rocksdb = { version = "0.21.0", optional = true }
+rocksdb = { version = "0.23.0", optional = true }
 [profile.release]
 lto = true
 

--- a/omnipaxos_storage/src/persistent_storage.rs
+++ b/omnipaxos_storage/src/persistent_storage.rs
@@ -2,7 +2,11 @@ use omnipaxos::{
     ballot_leader_election::Ballot,
     storage::{Entry, StopSign, Storage, StorageOp, StorageResult},
 };
-use rocksdb::{ColumnFamilyDescriptor, ColumnFamilyRef, Options, WriteBatchWithTransaction, DB};
+pub use rocksdb::{
+    statistics::{Histogram, HistogramData},
+    Options,
+};
+use rocksdb::{ColumnFamilyDescriptor, ColumnFamilyRef, WriteBatchWithTransaction, DB};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use zerocopy::{AsBytes, FromBytes};


### PR DESCRIPTION

New rocksdb version, expose Stats metrics as `Histogram` and `Counter` type.
https://github.com/rust-rocksdb/rust-rocksdb/pull/853/files
